### PR TITLE
Issue #6: prove detection latency within 90 seconds

### DIFF
--- a/docs/qa/traceability-matrix.md
+++ b/docs/qa/traceability-matrix.md
@@ -12,7 +12,7 @@
 | REQ-003 | As an on-call responder, I want a dashboard of current monitor status and open incidents so that I can see what needs attention immediately. | [#3](https://github.com/IDNTEQ/site-monitor/issues/3) |  | `` |  | Pending |
 | REQ-004 | As an on-call responder, I want an incident timeline with failure evidence so that I can triage without searching raw logs elsewhere. | [#4](https://github.com/IDNTEQ/site-monitor/issues/4) |  | `` |  | Pending |
 | REQ-005 | As an on-call responder, I want to acknowledge, mute, and resolve incidents so that the team has clear operational ownership during an outage. | [#5](https://github.com/IDNTEQ/site-monitor/issues/5) |  | `` |  | Pending |
-| NFR-001 | Detection latency | [#6](https://github.com/IDNTEQ/site-monitor/issues/6) |  | `` |  | Pending |
+| NFR-001 | Detection latency | [#6](https://github.com/IDNTEQ/site-monitor/issues/6) |  | `test/integration/detection-latency.test.js:24` | Timestamped worker integration test pending PR evidence | Implemented |
 | NFR-002 | Check execution reliability | [#7](https://github.com/IDNTEQ/site-monitor/issues/7) |  | `` |  | Pending |
 | NFR-003 | Dashboard load time | [#8](https://github.com/IDNTEQ/site-monitor/issues/8) |  | `` |  | Pending |
 | NFR-004 | Accessibility | [#9](https://github.com/IDNTEQ/site-monitor/issues/9) |  | `` |  | Pending |

--- a/docs/qa/traceability-matrix.md
+++ b/docs/qa/traceability-matrix.md
@@ -12,7 +12,7 @@
 | REQ-003 | As an on-call responder, I want a dashboard of current monitor status and open incidents so that I can see what needs attention immediately. | [#3](https://github.com/IDNTEQ/site-monitor/issues/3) |  | `` |  | Pending |
 | REQ-004 | As an on-call responder, I want an incident timeline with failure evidence so that I can triage without searching raw logs elsewhere. | [#4](https://github.com/IDNTEQ/site-monitor/issues/4) |  | `` |  | Pending |
 | REQ-005 | As an on-call responder, I want to acknowledge, mute, and resolve incidents so that the team has clear operational ownership during an outage. | [#5](https://github.com/IDNTEQ/site-monitor/issues/5) |  | `` |  | Pending |
-| NFR-001 | Detection latency | [#6](https://github.com/IDNTEQ/site-monitor/issues/6) |  | `test/integration/detection-latency.test.js:24` | Timestamped worker integration test pending PR evidence | Implemented |
+| NFR-001 | Detection latency | [#6](https://github.com/IDNTEQ/site-monitor/issues/6) | [#13](https://github.com/IDNTEQ/site-monitor/pull/13) | `test/integration/detection-latency.test.js:24` | Timestamped worker integration test captured in PR #13 | Implemented |
 | NFR-002 | Check execution reliability | [#7](https://github.com/IDNTEQ/site-monitor/issues/7) |  | `` |  | Pending |
 | NFR-003 | Dashboard load time | [#8](https://github.com/IDNTEQ/site-monitor/issues/8) |  | `` |  | Pending |
 | NFR-004 | Accessibility | [#9](https://github.com/IDNTEQ/site-monitor/issues/9) |  | `` |  | Pending |

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "site-monitor",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/src/monitoring/in-memory-repositories.js
+++ b/src/monitoring/in-memory-repositories.js
@@ -1,0 +1,81 @@
+import { randomUUID } from "node:crypto";
+
+function toMilliseconds(timestamp) {
+  return Date.parse(timestamp);
+}
+
+export class InMemoryMonitorRepository {
+  #monitors = new Map();
+
+  add(monitor) {
+    this.#monitors.set(monitor.id, { ...monitor });
+  }
+
+  listDue(asOfTimestamp) {
+    const asOfMs = toMilliseconds(asOfTimestamp);
+
+    return [...this.#monitors.values()]
+      .filter((monitor) => {
+        if (monitor.status !== "active") {
+          return false;
+        }
+
+        return toMilliseconds(monitor.nextCheckAt) <= asOfMs;
+      })
+      .map((monitor) => ({ ...monitor }));
+  }
+
+  save(monitor) {
+    this.#monitors.set(monitor.id, { ...monitor });
+  }
+
+  get(id) {
+    const monitor = this.#monitors.get(id);
+    return monitor ? { ...monitor } : null;
+  }
+}
+
+export class InMemoryCheckResultRepository {
+  #results = [];
+
+  create(checkResult) {
+    const record = {
+      id: randomUUID(),
+      ...checkResult,
+    };
+
+    this.#results.push(record);
+    return { ...record };
+  }
+
+  listByMonitorId(monitorId) {
+    return this.#results
+      .filter((result) => result.monitorId === monitorId)
+      .map((result) => ({ ...result }));
+  }
+}
+
+export class InMemoryIncidentRepository {
+  #incidents = [];
+
+  findOpenByMonitorId(monitorId) {
+    const incident =
+      this.#incidents.find(
+        (candidate) =>
+          candidate.monitorId === monitorId && candidate.state === "open",
+      ) ?? null;
+
+    return incident ? { ...incident } : null;
+  }
+
+  open(incident) {
+    const record = {
+      id: randomUUID(),
+      state: "open",
+      ...incident,
+    };
+
+    this.#incidents.push(record);
+    return { ...record };
+  }
+}

--- a/src/time/manual-clock.js
+++ b/src/time/manual-clock.js
@@ -1,0 +1,20 @@
+export class ManualClock {
+  #nowMs;
+
+  constructor(seedTimestamp) {
+    this.#nowMs = Date.parse(seedTimestamp);
+
+    if (Number.isNaN(this.#nowMs)) {
+      throw new Error(`Invalid seed timestamp: ${seedTimestamp}`);
+    }
+  }
+
+  now() {
+    return new Date(this.#nowMs).toISOString();
+  }
+
+  advanceBy(milliseconds) {
+    this.#nowMs += milliseconds;
+    return this.now();
+  }
+}

--- a/src/worker/scheduled-check-worker.js
+++ b/src/worker/scheduled-check-worker.js
@@ -1,0 +1,80 @@
+const MILLISECONDS_PER_SECOND = 1_000;
+
+function addSeconds(timestamp, seconds) {
+  return new Date(
+    Date.parse(timestamp) + seconds * MILLISECONDS_PER_SECOND,
+  ).toISOString();
+}
+
+export class ScheduledCheckWorker {
+  constructor({
+    clock,
+    monitorRepository,
+    checkResultRepository,
+    incidentRepository,
+    checkExecutor,
+  }) {
+    this.clock = clock;
+    this.monitorRepository = monitorRepository;
+    this.checkResultRepository = checkResultRepository;
+    this.incidentRepository = incidentRepository;
+    this.checkExecutor = checkExecutor;
+  }
+
+  async runDueChecks() {
+    const executedAt = this.clock.now();
+    const dueMonitors = this.monitorRepository.listDue(executedAt);
+    const monitorRuns = [];
+
+    for (const monitor of dueMonitors) {
+      const outcome = await this.checkExecutor.execute({
+        monitor,
+        executedAt,
+      });
+
+      const checkResult = this.checkResultRepository.create({
+        monitorId: monitor.id,
+        checkedAt: executedAt,
+        outcome: outcome.ok ? "pass" : "fail",
+        statusCode: outcome.statusCode ?? null,
+        error: outcome.error ?? null,
+      });
+
+      if (outcome.ok) {
+        monitor.consecutiveFailures = 0;
+      } else {
+        monitor.consecutiveFailures = (monitor.consecutiveFailures ?? 0) + 1;
+
+        const openIncident = this.incidentRepository.findOpenByMonitorId(
+          monitor.id,
+        );
+
+        if (
+          !openIncident &&
+          monitor.consecutiveFailures >= monitor.failureThreshold
+        ) {
+          this.incidentRepository.open({
+            monitorId: monitor.id,
+            openedAt: executedAt,
+            triggerCheckResultId: checkResult.id,
+          });
+        }
+      }
+
+      monitor.lastCheckedAt = executedAt;
+      monitor.nextCheckAt = addSeconds(executedAt, monitor.intervalSeconds);
+      this.monitorRepository.save(monitor);
+
+      monitorRuns.push({
+        monitorId: monitor.id,
+        checkedAt: executedAt,
+        outcome: checkResult.outcome,
+      });
+    }
+
+    return {
+      executedAt,
+      monitorRuns,
+    };
+  }
+}

--- a/test/integration/detection-latency.test.js
+++ b/test/integration/detection-latency.test.js
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  InMemoryCheckResultRepository,
+  InMemoryIncidentRepository,
+  InMemoryMonitorRepository,
+} from "../../src/monitoring/in-memory-repositories.js";
+import { ManualClock } from "../../src/time/manual-clock.js";
+import { ScheduledCheckWorker } from "../../src/worker/scheduled-check-worker.js";
+
+class ThresholdBreachExecutor {
+  constructor({ breachAt }) {
+    this.breachAt = Date.parse(breachAt);
+  }
+
+  async execute({ executedAt }) {
+    return Date.parse(executedAt) >= this.breachAt
+      ? { ok: false, statusCode: 503, error: "threshold_breached" }
+      : { ok: true, statusCode: 200 };
+  }
+}
+
+test(
+  "a 60-second monitor opens an incident within 90 seconds of threshold breach",
+  async () => {
+    const clock = new ManualClock("2026-04-06T00:00:00.000Z");
+    const breachAt = "2026-04-06T00:00:30.000Z";
+    const monitorRepository = new InMemoryMonitorRepository();
+    const checkResultRepository = new InMemoryCheckResultRepository();
+    const incidentRepository = new InMemoryIncidentRepository();
+
+    monitorRepository.add({
+      id: "monitor-1",
+      status: "active",
+      intervalSeconds: 60,
+      failureThreshold: 1,
+      consecutiveFailures: 0,
+      nextCheckAt: clock.now(),
+      lastCheckedAt: null,
+    });
+
+    const worker = new ScheduledCheckWorker({
+      clock,
+      monitorRepository,
+      checkResultRepository,
+      incidentRepository,
+      checkExecutor: new ThresholdBreachExecutor({ breachAt }),
+    });
+
+    await worker.runDueChecks();
+    clock.advanceBy(30_000);
+
+    const earlyRun = await worker.runDueChecks();
+    assert.equal(earlyRun.monitorRuns.length, 0);
+
+    clock.advanceBy(30_000);
+    const scheduledRun = await worker.runDueChecks();
+
+    assert.equal(scheduledRun.executedAt, "2026-04-06T00:01:00.000Z");
+    assert.deepEqual(scheduledRun.monitorRuns, [
+      {
+        monitorId: "monitor-1",
+        checkedAt: "2026-04-06T00:01:00.000Z",
+        outcome: "fail",
+      },
+    ]);
+
+    const incident = incidentRepository.findOpenByMonitorId("monitor-1");
+    assert.ok(incident);
+    assert.equal(incident.openedAt, "2026-04-06T00:01:00.000Z");
+
+    const latencyMs = Date.parse(incident.openedAt) - Date.parse(breachAt);
+    assert.equal(latencyMs, 30_000);
+    assert.ok(latencyMs <= 90_000);
+
+    assert.deepEqual(
+      checkResultRepository
+        .listByMonitorId("monitor-1")
+        .map(({ checkedAt, outcome, statusCode }) => ({
+          checkedAt,
+          outcome,
+          statusCode,
+        })),
+      [
+        {
+          checkedAt: "2026-04-06T00:00:00.000Z",
+          outcome: "pass",
+          statusCode: 200,
+        },
+        {
+          checkedAt: "2026-04-06T00:01:00.000Z",
+          outcome: "fail",
+          statusCode: 503,
+        },
+      ],
+    );
+  },
+);


### PR DESCRIPTION
Summary: add a minimal scheduled worker core for monitor execution and incident opening; add a timestamped integration test that simulates a threshold breach between 60-second runs and proves 30-second detection latency; update traceability for NFR-001. Reviewer verify: run npm test; inspect test/integration/detection-latency.test.js; confirm breach at 2026-04-06T00:00:30.000Z and incident opening at 2026-04-06T00:01:00.000Z. Advances #6 only.