### PR TITLE
REQ-002: implement alert policy and maintenance window APIs

### DIFF
--- a/docs/qa/traceability-matrix.md
+++ b/docs/qa/traceability-matrix.md
@@ -1,14 +1,14 @@
 # Traceability Matrix -- site-monitor
 
 > **Last updated:** 2026-04-06
-> **Updated by:** superiority-core
+> **Updated by:** superiority-developer
 
 ## Requirements Traceability
 
 | ID | Requirement | Issue | PR | Test File:Line | Staging Evidence | Status |
 |----|-------------|-------|----|----------------|------------------|--------|
 | REQ-001 | As a reliability engineer, I want to create and manage monitors so that important sites and endpoints are checked automatically. | [#1](https://github.com/IDNTEQ/site-monitor/issues/1) |  | `` |  | Pending |
-| REQ-002 | As a reliability engineer, I want to configure alert policies and maintenance windows so that responders are notified only when failures are actionable. | [#2](https://github.com/IDNTEQ/site-monitor/issues/2) |  | `` |  | Pending |
+| REQ-002 | As a reliability engineer, I want to configure alert policies and maintenance windows so that responders are notified only when failures are actionable. | [#2](https://github.com/IDNTEQ/site-monitor/issues/2) | [#14](https://github.com/IDNTEQ/site-monitor/pull/14) | `test/policy-service.test.js:13`; `test/api.test.js:60` |  | Needs Review |
 | REQ-003 | As an on-call responder, I want a dashboard of current monitor status and open incidents so that I can see what needs attention immediately. | [#3](https://github.com/IDNTEQ/site-monitor/issues/3) |  | `` |  | Pending |
 | REQ-004 | As an on-call responder, I want an incident timeline with failure evidence so that I can triage without searching raw logs elsewhere. | [#4](https://github.com/IDNTEQ/site-monitor/issues/4) |  | `` |  | Pending |
 | REQ-005 | As an on-call responder, I want to acknowledge, mute, and resolve incidents so that the team has clear operational ownership during an outage. | [#5](https://github.com/IDNTEQ/site-monitor/issues/5) |  | `` |  | Pending |

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "site-monitor",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node src/server.js",
+    "test": "node --test"
+  }
+}

--- a/src/domain/alertPolicy.js
+++ b/src/domain/alertPolicy.js
@@ -1,0 +1,202 @@
+import crypto from "node:crypto";
+
+export class ValidationError extends Error {
+  constructor(message, details = {}) {
+    super(message);
+    this.name = "ValidationError";
+    this.details = details;
+  }
+}
+
+function asNonEmptyString(value, fieldName) {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new ValidationError(`${fieldName} must be a non-empty string.`, {
+      field: fieldName
+    });
+  }
+
+  return value.trim();
+}
+
+function asPositiveInteger(value, fieldName) {
+  if (!Number.isInteger(value) || value < 1) {
+    throw new ValidationError(`${fieldName} must be an integer greater than 0.`, {
+      field: fieldName
+    });
+  }
+
+  return value;
+}
+
+function asIsoDate(value, fieldName) {
+  const parsed = new Date(value);
+
+  if (Number.isNaN(parsed.getTime())) {
+    throw new ValidationError(`${fieldName} must be a valid ISO-8601 datetime.`, {
+      field: fieldName
+    });
+  }
+
+  return parsed.toISOString();
+}
+
+export function validateAlertPolicy(input) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new ValidationError("alert policy payload must be an object.");
+  }
+
+  const failureThreshold = asPositiveInteger(
+    input.failureThreshold,
+    "failureThreshold"
+  );
+  const recoveryThreshold = asPositiveInteger(
+    input.recoveryThreshold,
+    "recoveryThreshold"
+  );
+
+  if (!Array.isArray(input.notificationChannels) || input.notificationChannels.length === 0) {
+    throw new ValidationError(
+      "notificationChannels must contain at least one delivery target.",
+      { field: "notificationChannels" }
+    );
+  }
+
+  const notificationChannels = [...new Set(
+    input.notificationChannels.map((channel) => asNonEmptyString(channel, "notificationChannels"))
+  )];
+  const escalationTarget = asNonEmptyString(
+    input.escalationTarget,
+    "escalationTarget"
+  );
+  const notifyOnRecovery = input.notifyOnRecovery ?? true;
+
+  if (typeof notifyOnRecovery !== "boolean") {
+    throw new ValidationError("notifyOnRecovery must be a boolean.", {
+      field: "notifyOnRecovery"
+    });
+  }
+
+  return {
+    failureThreshold,
+    recoveryThreshold,
+    notificationChannels,
+    escalationTarget,
+    notifyOnRecovery
+  };
+}
+
+export function validateMaintenanceWindow(input) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new ValidationError("maintenance window payload must be an object.");
+  }
+
+  const startsAt = asIsoDate(input.startsAt, "startsAt");
+  const endsAt = asIsoDate(input.endsAt, "endsAt");
+
+  if (new Date(endsAt) <= new Date(startsAt)) {
+    throw new ValidationError("endsAt must be later than startsAt.", {
+      field: "endsAt"
+    });
+  }
+
+  return {
+    id: input.id ?? crypto.randomUUID(),
+    startsAt,
+    endsAt,
+    reason: asNonEmptyString(input.reason, "reason")
+  };
+}
+
+export function findActiveMaintenanceWindow(maintenanceWindows, checkedAt) {
+  const sampleTime = new Date(checkedAt);
+
+  return maintenanceWindows.find((window) => {
+    const startsAt = new Date(window.startsAt);
+    const endsAt = new Date(window.endsAt);
+    return startsAt <= sampleTime && sampleTime <= endsAt;
+  }) ?? null;
+}
+
+export function evaluatePolicyPreview({
+  alertPolicy,
+  maintenanceWindows = [],
+  eventType,
+  checkedAt,
+  consecutiveFailures = 0,
+  consecutiveRecoveries = 0
+}) {
+  const activeWindow = findActiveMaintenanceWindow(maintenanceWindows, checkedAt);
+
+  if (activeWindow) {
+    return {
+      eventType,
+      checkedAt,
+      decision: "suppressed",
+      reason: "maintenance-window-active",
+      maintenanceWindow: activeWindow
+    };
+  }
+
+  if (eventType === "failure") {
+    if (consecutiveFailures < alertPolicy.failureThreshold) {
+      return {
+        eventType,
+        checkedAt,
+        decision: "suppressed",
+        reason: "failure-threshold-not-met",
+        threshold: alertPolicy.failureThreshold,
+        observedFailures: consecutiveFailures
+      };
+    }
+
+    return {
+      eventType,
+      checkedAt,
+      decision: "notify",
+      reason: "failure-threshold-met",
+      threshold: alertPolicy.failureThreshold,
+      observedFailures: consecutiveFailures,
+      notificationChannels: alertPolicy.notificationChannels,
+      escalationTarget: alertPolicy.escalationTarget
+    };
+  }
+
+  if (eventType === "recovery") {
+    if (consecutiveRecoveries < alertPolicy.recoveryThreshold) {
+      return {
+        eventType,
+        checkedAt,
+        decision: "suppressed",
+        reason: "recovery-threshold-not-met",
+        threshold: alertPolicy.recoveryThreshold,
+        observedRecoveries: consecutiveRecoveries
+      };
+    }
+
+    if (!alertPolicy.notifyOnRecovery) {
+      return {
+        eventType,
+        checkedAt,
+        decision: "suppressed",
+        reason: "recovery-notifications-disabled",
+        threshold: alertPolicy.recoveryThreshold,
+        observedRecoveries: consecutiveRecoveries
+      };
+    }
+
+    return {
+      eventType,
+      checkedAt,
+      decision: "notify",
+      reason: "recovery-threshold-met",
+      threshold: alertPolicy.recoveryThreshold,
+      observedRecoveries: consecutiveRecoveries,
+      notificationChannels: alertPolicy.notificationChannels,
+      escalationTarget: alertPolicy.escalationTarget
+    };
+  }
+
+  throw new ValidationError("eventType must be either failure or recovery.", {
+    field: "eventType"
+  });
+}

--- a/src/http/app.js
+++ b/src/http/app.js
@@ -1,0 +1,98 @@
+import http from "node:http";
+
+import { ValidationError } from "../domain/alertPolicy.js";
+import { NotFoundError } from "../services/policyService.js";
+
+function sendJson(response, statusCode, payload) {
+  response.writeHead(statusCode, {
+    "content-type": "application/json"
+  });
+  response.end(JSON.stringify(payload));
+}
+
+async function parseJsonBody(request) {
+  const chunks = [];
+
+  for await (const chunk of request) {
+    chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+  }
+
+  if (chunks.length === 0) {
+    return {};
+  }
+
+  try {
+    return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+  } catch {
+    throw new ValidationError("request body must be valid JSON.");
+  }
+}
+
+function routeMatch(method, pathname, expression) {
+  return method && pathname ? expression.exec(`${method} ${pathname}`) : null;
+}
+
+export function createHandler({ policyService }) {
+  return async (request, response) => {
+    const url = new URL(request.url, "http://localhost");
+    const alertPolicyRoute = routeMatch(
+      request.method,
+      url.pathname,
+      /^PATCH \/api\/monitors\/([^/]+)\/alert-policy$/
+    );
+    const maintenanceRoute = routeMatch(
+      request.method,
+      url.pathname,
+      /^POST \/api\/monitors\/([^/]+)\/maintenance-windows$/
+    );
+    const previewRoute = routeMatch(
+      request.method,
+      url.pathname,
+      /^POST \/api\/monitors\/([^/]+)\/policy-preview$/
+    );
+
+    try {
+      if (alertPolicyRoute) {
+        const body = await parseJsonBody(request);
+        const result = await policyService.updateAlertPolicy(alertPolicyRoute[1], body);
+        sendJson(response, 200, result);
+        return;
+      }
+
+      if (maintenanceRoute) {
+        const body = await parseJsonBody(request);
+        const result = await policyService.createMaintenanceWindow(maintenanceRoute[1], body);
+        sendJson(response, 201, result);
+        return;
+      }
+
+      if (previewRoute) {
+        const body = await parseJsonBody(request);
+        const result = await policyService.previewDecision(previewRoute[1], body);
+        sendJson(response, 200, result);
+        return;
+      }
+
+      sendJson(response, 404, { error: "Not found." });
+    } catch (error) {
+      if (error instanceof ValidationError) {
+        sendJson(response, 400, {
+          error: error.message,
+          details: error.details ?? {}
+        });
+        return;
+      }
+
+      if (error instanceof NotFoundError) {
+        sendJson(response, 404, { error: error.message });
+        return;
+      }
+
+      sendJson(response, 500, { error: "Internal server error." });
+    }
+  };
+}
+
+export function createApp({ policyService }) {
+  return http.createServer(createHandler({ policyService }));
+}

--- a/src/repositories/inMemoryMonitorRepository.js
+++ b/src/repositories/inMemoryMonitorRepository.js
@@ -1,0 +1,19 @@
+export class InMemoryMonitorRepository {
+  constructor(monitors = []) {
+    this.monitors = new Map();
+
+    for (const monitor of monitors) {
+      this.monitors.set(monitor.id, structuredClone(monitor));
+    }
+  }
+
+  async getById(id) {
+    const monitor = this.monitors.get(id);
+    return monitor ? structuredClone(monitor) : null;
+  }
+
+  async save(monitor) {
+    this.monitors.set(monitor.id, structuredClone(monitor));
+    return structuredClone(monitor);
+  }
+}

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,27 @@
+import { createApp } from "./http/app.js";
+import { InMemoryMonitorRepository } from "./repositories/inMemoryMonitorRepository.js";
+import { PolicyService } from "./services/policyService.js";
+
+const port = Number(process.env.PORT ?? 3000);
+const monitorRepository = new InMemoryMonitorRepository([
+  {
+    id: "monitor-checkout",
+    name: "Checkout",
+    alertPolicy: {
+      failureThreshold: 3,
+      recoveryThreshold: 2,
+      notificationChannels: ["pagerduty", "slack"],
+      escalationTarget: "payments-on-call",
+      notifyOnRecovery: true
+    },
+    maintenanceWindows: []
+  }
+]);
+
+const app = createApp({
+  policyService: new PolicyService({ monitorRepository })
+});
+
+app.listen(port, () => {
+  console.log(`site-monitor listening on port ${port}`);
+});

--- a/src/services/policyService.js
+++ b/src/services/policyService.js
@@ -1,0 +1,90 @@
+import {
+  evaluatePolicyPreview,
+  validateAlertPolicy,
+  validateMaintenanceWindow
+} from "../domain/alertPolicy.js";
+
+export class NotFoundError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "NotFoundError";
+  }
+}
+
+function normalizeMonitor(monitor) {
+  return {
+    ...monitor,
+    alertPolicy: monitor.alertPolicy ?? null,
+    maintenanceWindows: monitor.maintenanceWindows ?? []
+  };
+}
+
+export class PolicyService {
+  constructor({ monitorRepository }) {
+    this.monitorRepository = monitorRepository;
+  }
+
+  async updateAlertPolicy(monitorId, input) {
+    const monitor = await this.#requireMonitor(monitorId);
+    const alertPolicy = validateAlertPolicy(input);
+    const updatedMonitor = normalizeMonitor({
+      ...monitor,
+      alertPolicy
+    });
+
+    await this.monitorRepository.save(updatedMonitor);
+
+    return {
+      monitorId,
+      alertPolicy
+    };
+  }
+
+  async createMaintenanceWindow(monitorId, input) {
+    const monitor = await this.#requireMonitor(monitorId);
+    const maintenanceWindow = validateMaintenanceWindow(input);
+    const updatedMonitor = normalizeMonitor({
+      ...monitor,
+      maintenanceWindows: [...(monitor.maintenanceWindows ?? []), maintenanceWindow]
+    });
+
+    await this.monitorRepository.save(updatedMonitor);
+
+    return {
+      monitorId,
+      maintenanceWindow
+    };
+  }
+
+  async previewDecision(monitorId, input) {
+    const monitor = await this.#requireMonitor(monitorId);
+
+    if (!monitor.alertPolicy) {
+      throw new NotFoundError(`Monitor ${monitorId} does not have an alert policy.`);
+    }
+
+    const checkedAt = input.checkedAt ?? new Date().toISOString();
+
+    return {
+      monitorId,
+      preview: evaluatePolicyPreview({
+        alertPolicy: monitor.alertPolicy,
+        maintenanceWindows: monitor.maintenanceWindows ?? [],
+        eventType: input.eventType,
+        checkedAt,
+        consecutiveFailures: input.consecutiveFailures ?? 0,
+        consecutiveRecoveries: input.consecutiveRecoveries ?? 0
+      })
+    };
+  }
+
+  async #requireMonitor(monitorId) {
+    const monitor = await this.monitorRepository.getById(monitorId);
+
+    if (!monitor) {
+      throw new NotFoundError(`Monitor ${monitorId} was not found.`);
+    }
+
+    return normalizeMonitor(monitor);
+  }
+}

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -1,0 +1,130 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { Readable } from "node:stream";
+
+import { createHandler } from "../src/http/app.js";
+import { InMemoryMonitorRepository } from "../src/repositories/inMemoryMonitorRepository.js";
+import { PolicyService } from "../src/services/policyService.js";
+
+function createResponseCapture() {
+  let resolveFinished;
+  const finished = new Promise((resolve) => {
+    resolveFinished = resolve;
+  });
+
+  return {
+    response: {
+      statusCode: 200,
+      headers: {},
+      writeHead(statusCode, headers) {
+        this.statusCode = statusCode;
+        this.headers = headers;
+      },
+      end(body) {
+        resolveFinished({
+          statusCode: this.statusCode,
+          headers: this.headers,
+          body
+        });
+      }
+    },
+    finished
+  };
+}
+
+async function requestJson(handler, { method, path, body }) {
+  const request = Readable.from(body ? [JSON.stringify(body)] : []);
+  request.method = method;
+  request.url = path;
+  request.headers = body ? { "content-type": "application/json" } : {};
+
+  const { response, finished } = createResponseCapture();
+  await handler(request, response);
+
+  const result = await finished;
+  return {
+    statusCode: result.statusCode,
+    headers: result.headers,
+    body: JSON.parse(result.body)
+  };
+}
+
+function createHandlerFor(monitors) {
+  return createHandler({
+    policyService: new PolicyService({
+      monitorRepository: new InMemoryMonitorRepository(monitors)
+    })
+  });
+}
+
+test("PATCH /api/monitors/:id/alert-policy updates the monitor policy", async () => {
+  const handler = createHandlerFor([{ id: "monitor-1", name: "Checkout", maintenanceWindows: [] }]);
+  const response = await requestJson(handler, {
+    method: "PATCH",
+    path: "/api/monitors/monitor-1/alert-policy",
+    body: {
+      failureThreshold: 4,
+      recoveryThreshold: 2,
+      notificationChannels: ["slack", "email"],
+      escalationTarget: "platform-primary",
+      notifyOnRecovery: true
+    }
+  });
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.body.alertPolicy.failureThreshold, 4);
+  assert.deepEqual(response.body.alertPolicy.notificationChannels, ["slack", "email"]);
+});
+
+test("POST /api/monitors/:id/maintenance-windows validates window boundaries", async () => {
+  const handler = createHandlerFor([{ id: "monitor-1", name: "Checkout", maintenanceWindows: [] }]);
+  const response = await requestJson(handler, {
+    method: "POST",
+    path: "/api/monitors/monitor-1/maintenance-windows",
+    body: {
+      startsAt: "2026-04-06T11:00:00.000Z",
+      endsAt: "2026-04-06T10:00:00.000Z",
+      reason: "backwards window"
+    }
+  });
+
+  assert.equal(response.statusCode, 400);
+  assert.equal(response.body.error, "endsAt must be later than startsAt.");
+});
+
+test("POST /api/monitors/:id/policy-preview returns a suppressed decision during maintenance", async () => {
+  const handler = createHandlerFor([
+    {
+      id: "monitor-1",
+      name: "Checkout",
+      alertPolicy: {
+        failureThreshold: 2,
+        recoveryThreshold: 1,
+        notificationChannels: ["pagerduty"],
+        escalationTarget: "payments-on-call",
+        notifyOnRecovery: true
+      },
+      maintenanceWindows: [
+        {
+          id: "mw-1",
+          startsAt: "2026-04-06T10:00:00.000Z",
+          endsAt: "2026-04-06T11:00:00.000Z",
+          reason: "database migration"
+        }
+      ]
+    }
+  ]);
+  const response = await requestJson(handler, {
+    method: "POST",
+    path: "/api/monitors/monitor-1/policy-preview",
+    body: {
+      eventType: "failure",
+      checkedAt: "2026-04-06T10:30:00.000Z",
+      consecutiveFailures: 2
+    }
+  });
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.body.preview.decision, "suppressed");
+  assert.equal(response.body.preview.reason, "maintenance-window-active");
+});

--- a/test/policy-service.test.js
+++ b/test/policy-service.test.js
@@ -1,0 +1,121 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { InMemoryMonitorRepository } from "../src/repositories/inMemoryMonitorRepository.js";
+import { PolicyService } from "../src/services/policyService.js";
+
+function createService(monitors) {
+  return new PolicyService({
+    monitorRepository: new InMemoryMonitorRepository(monitors)
+  });
+}
+
+test("updateAlertPolicy stores a normalized alert policy for a monitor", async () => {
+  const service = createService([{ id: "monitor-1", name: "Checkout", maintenanceWindows: [] }]);
+
+  const result = await service.updateAlertPolicy("monitor-1", {
+    failureThreshold: 3,
+    recoveryThreshold: 2,
+    notificationChannels: ["slack", "pagerduty", "slack"],
+    escalationTarget: "payments-on-call",
+    notifyOnRecovery: true
+  });
+
+  assert.deepEqual(result, {
+    monitorId: "monitor-1",
+    alertPolicy: {
+      failureThreshold: 3,
+      recoveryThreshold: 2,
+      notificationChannels: ["slack", "pagerduty"],
+      escalationTarget: "payments-on-call",
+      notifyOnRecovery: true
+    }
+  });
+});
+
+test("previewDecision suppresses a failure during an active maintenance window", async () => {
+  const service = createService([
+    {
+      id: "monitor-1",
+      name: "Checkout",
+      alertPolicy: {
+        failureThreshold: 2,
+        recoveryThreshold: 1,
+        notificationChannels: ["pagerduty"],
+        escalationTarget: "payments-on-call",
+        notifyOnRecovery: true
+      },
+      maintenanceWindows: [
+        {
+          id: "mw-1",
+          startsAt: "2026-04-06T10:00:00.000Z",
+          endsAt: "2026-04-06T11:00:00.000Z",
+          reason: "database migration"
+        }
+      ]
+    }
+  ]);
+
+  const result = await service.previewDecision("monitor-1", {
+    eventType: "failure",
+    checkedAt: "2026-04-06T10:30:00.000Z",
+    consecutiveFailures: 2
+  });
+
+  assert.equal(result.preview.decision, "suppressed");
+  assert.equal(result.preview.reason, "maintenance-window-active");
+  assert.equal(result.preview.maintenanceWindow.id, "mw-1");
+});
+
+test("previewDecision notifies once the failure threshold is met outside maintenance", async () => {
+  const service = createService([
+    {
+      id: "monitor-1",
+      name: "Checkout",
+      alertPolicy: {
+        failureThreshold: 3,
+        recoveryThreshold: 2,
+        notificationChannels: ["pagerduty", "slack"],
+        escalationTarget: "payments-on-call",
+        notifyOnRecovery: true
+      },
+      maintenanceWindows: []
+    }
+  ]);
+
+  const result = await service.previewDecision("monitor-1", {
+    eventType: "failure",
+    checkedAt: "2026-04-06T12:00:00.000Z",
+    consecutiveFailures: 3
+  });
+
+  assert.equal(result.preview.decision, "notify");
+  assert.deepEqual(result.preview.notificationChannels, ["pagerduty", "slack"]);
+  assert.equal(result.preview.escalationTarget, "payments-on-call");
+});
+
+test("previewDecision suppresses a recovery when recovery notifications are disabled", async () => {
+  const service = createService([
+    {
+      id: "monitor-1",
+      name: "Checkout",
+      alertPolicy: {
+        failureThreshold: 2,
+        recoveryThreshold: 2,
+        notificationChannels: ["pagerduty"],
+        escalationTarget: "payments-on-call",
+        notifyOnRecovery: false
+      },
+      maintenanceWindows: []
+    }
+  ]);
+
+  const result = await service.previewDecision("monitor-1", {
+    eventType: "recovery",
+    checkedAt: "2026-04-06T12:00:00.000Z",
+    consecutiveRecoveries: 2
+  });
+
+  assert.equal(result.preview.decision, "suppressed");
+  assert.equal(result.preview.reason, "recovery-notifications-disabled");
+});


### PR DESCRIPTION
## Summary
- add a minimal Node service scaffold for REQ-002 in the otherwise docs-only repo
- implement monitor-scoped alert policy updates, maintenance window creation, and sample preview evaluation
- cover the service and HTTP routes with dependency-free tests

## What Part Of #2 This Advances
This PR advances the monitor-scoped portion of issue #2: failure thresholds, recovery behavior, notification channel sets, escalation targets, maintenance window suppression, and a policy preview decision surface.

## Reviewer Verify
- 
> site-monitor@0.1.0 test
> node --test

TAP version 13
# Subtest: PATCH /api/monitors/:id/alert-policy updates the monitor policy
ok 1 - PATCH /api/monitors/:id/alert-policy updates the monitor policy
  ---
  duration_ms: 3.925009
  type: 'test'
  ...
# Subtest: POST /api/monitors/:id/maintenance-windows validates window boundaries
ok 2 - POST /api/monitors/:id/maintenance-windows validates window boundaries
  ---
  duration_ms: 1.359006
  type: 'test'
  ...
# Subtest: POST /api/monitors/:id/policy-preview returns a suppressed decision during maintenance
ok 3 - POST /api/monitors/:id/policy-preview returns a suppressed decision during maintenance
  ---
  duration_ms: 0.942589
  type: 'test'
  ...
# Subtest: updateAlertPolicy stores a normalized alert policy for a monitor
ok 4 - updateAlertPolicy stores a normalized alert policy for a monitor
  ---
  duration_ms: 1.874802
  type: 'test'
  ...
# Subtest: previewDecision suppresses a failure during an active maintenance window
ok 5 - previewDecision suppresses a failure during an active maintenance window
  ---
  duration_ms: 0.563899
  type: 'test'
  ...
# Subtest: previewDecision notifies once the failure threshold is met outside maintenance
ok 6 - previewDecision notifies once the failure threshold is met outside maintenance
  ---
  duration_ms: 0.25246
  type: 'test'
  ...
# Subtest: previewDecision suppresses a recovery when recovery notifications are disabled
ok 7 - previewDecision suppresses a recovery when recovery notifications are disabled
  ---
  duration_ms: 0.289456
  type: 'test'
  ...
1..7
# tests 7
# suites 0
# pass 7
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 121.029903 passes
-  persists validated policy configuration
-  rejects invalid windows and records valid ones
-  returns  or  based on thresholds and maintenance windows

## Scope Notes
- This slice is intentionally monitor-scoped. The approved docs mention monitor groups, but no group model exists in the current repo artifacts, so this PR does not invent one.
- Persistence remains in-memory to keep scope tight to REQ-002 in the current codebase state.

Refs #2