### PR TITLE
[NFR-005] Encrypt stored monitor and notification secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+.env
+*.sqlite
+*.sqlite-shm
+*.sqlite-wal
+coverage/

--- a/docs/qa/traceability-matrix.md
+++ b/docs/qa/traceability-matrix.md
@@ -1,7 +1,7 @@
 # Traceability Matrix -- site-monitor
 
 > **Last updated:** 2026-04-06
-> **Updated by:** superiority-core
+> **Updated by:** superiority-developer
 
 ## Requirements Traceability
 
@@ -16,6 +16,6 @@
 | NFR-002 | Check execution reliability | [#7](https://github.com/IDNTEQ/site-monitor/issues/7) |  | `` |  | Pending |
 | NFR-003 | Dashboard load time | [#8](https://github.com/IDNTEQ/site-monitor/issues/8) |  | `` |  | Pending |
 | NFR-004 | Accessibility | [#9](https://github.com/IDNTEQ/site-monitor/issues/9) |  | `` |  | Pending |
-| NFR-005 | Secret handling | [#10](https://github.com/IDNTEQ/site-monitor/issues/10) |  | `` |  | Pending |
+| NFR-005 | Secret handling | [#10](https://github.com/IDNTEQ/site-monitor/issues/10) |  | `test/secret-handling.integration.test.js:13`, `test/secret-handling.integration.test.js:62` | `docs/security/nfr-005-secret-handling.md` | Needs Review |
 | NFR-006 | Auditability | [#11](https://github.com/IDNTEQ/site-monitor/issues/11) |  | `` |  | Pending |
 | NFR-007 | Mobile support | [#12](https://github.com/IDNTEQ/site-monitor/issues/12) |  | `` |  | Pending |

--- a/docs/security/nfr-005-secret-handling.md
+++ b/docs/security/nfr-005-secret-handling.md
@@ -1,0 +1,27 @@
+# NFR-005 Security Review -- Secret Handling
+
+## Scope
+
+This slice covers the first persisted secret paths in `site-monitor`:
+
+- monitor authentication secrets
+- notification channel credentials
+
+## Controls Implemented
+
+- Secrets are encrypted before database writes using AES-256-GCM with a process-supplied 32-byte key.
+- SQLite stores only ciphertext, IV, and auth tag material in versioned serialized form.
+- API create and read responses expose only `secretConfigured` booleans instead of plaintext secrets.
+- Decryption is not used in any HTTP response path.
+
+## Reviewer Checks
+
+- Confirm `SITE_MONITOR_SECRET_KEY` is provided through runtime configuration and not committed.
+- Confirm `src/repositories.js` only returns redacted secret metadata.
+- Confirm the integration test reads stored rows and proves the database values differ from the submitted plaintext.
+
+## Residual Risks
+
+- Key rotation is not implemented yet.
+- Secrets are decrypted only in tests right now; future runtime consumers must keep decrypted values out of logs and response bodies.
+- This slice does not yet integrate with an external KMS or secret manager.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "site-monitor",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node src/index.js",
+    "test": "node --test"
+  }
+}

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,77 @@
+import { createServer } from "node:http";
+import { URL } from "node:url";
+
+import {
+  createMonitorRepository,
+  createNotificationChannelRepository
+} from "./repositories.js";
+
+export function createApp({ database, encryptionKey }) {
+  const monitorRepository = createMonitorRepository(database, encryptionKey);
+  const notificationChannelRepository = createNotificationChannelRepository(database, encryptionKey);
+
+  return createServer(async (request, response) => {
+    const url = new URL(request.url, "http://127.0.0.1");
+
+    try {
+      if (request.method === "POST" && url.pathname === "/api/monitors") {
+        const payload = await readJsonBody(request);
+        const monitor = monitorRepository.create(payload);
+        return sendJson(response, 201, monitor);
+      }
+
+      if (request.method === "GET" && url.pathname.startsWith("/api/monitors/")) {
+        const monitorId = url.pathname.replace("/api/monitors/", "");
+        const monitor = monitorRepository.findById(monitorId);
+
+        if (!monitor) {
+          return sendJson(response, 404, { error: "Monitor not found." });
+        }
+
+        return sendJson(response, 200, monitor);
+      }
+
+      if (request.method === "POST" && url.pathname === "/api/notification-channels") {
+        const payload = await readJsonBody(request);
+        const channel = notificationChannelRepository.create(payload);
+        return sendJson(response, 201, channel);
+      }
+
+      if (request.method === "GET" && url.pathname.startsWith("/api/notification-channels/")) {
+        const channelId = url.pathname.replace("/api/notification-channels/", "");
+        const channel = notificationChannelRepository.findById(channelId);
+
+        if (!channel) {
+          return sendJson(response, 404, { error: "Notification channel not found." });
+        }
+
+        return sendJson(response, 200, channel);
+      }
+
+      return sendJson(response, 404, { error: "Route not found." });
+    } catch (error) {
+      return sendJson(response, 400, { error: error.message });
+    }
+  });
+}
+
+async function readJsonBody(request) {
+  const chunks = [];
+
+  for await (const chunk of request) {
+    chunks.push(chunk);
+  }
+
+  if (chunks.length === 0) {
+    throw new Error("Request body is required.");
+  }
+
+  return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+}
+
+function sendJson(response, statusCode, payload) {
+  response.writeHead(statusCode, {
+    "content-type": "application/json; charset=utf-8"
+  });
+  response.end(JSON.stringify(payload));
+}

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,27 @@
+const ENCRYPTION_KEY_BYTES = 32;
+
+export function loadConfig(env = process.env) {
+  const port = Number.parseInt(env.PORT ?? "3000", 10);
+  const databasePath = env.DATABASE_PATH ?? "./site-monitor.sqlite";
+  const encryptionKey = decodeBase64Key(env.SITE_MONITOR_SECRET_KEY);
+
+  return {
+    port,
+    databasePath,
+    encryptionKey
+  };
+}
+
+function decodeBase64Key(value) {
+  if (!value) {
+    throw new Error("SITE_MONITOR_SECRET_KEY must be set to a base64-encoded 32-byte key.");
+  }
+
+  const key = Buffer.from(value, "base64");
+
+  if (key.length !== ENCRYPTION_KEY_BYTES) {
+    throw new Error("SITE_MONITOR_SECRET_KEY must decode to exactly 32 bytes.");
+  }
+
+  return key;
+}

--- a/src/crypto.js
+++ b/src/crypto.js
@@ -1,0 +1,36 @@
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+
+const ALGORITHM = "aes-256-gcm";
+const IV_BYTES = 12;
+const FORMAT_VERSION = "v1";
+
+export function encryptSecret(plaintext, key) {
+  if (typeof plaintext !== "string" || plaintext.length === 0) {
+    throw new Error("Secret plaintext must be a non-empty string.");
+  }
+
+  const iv = randomBytes(IV_BYTES);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+  const ciphertext = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+
+  return [FORMAT_VERSION, iv.toString("base64url"), authTag.toString("base64url"), ciphertext.toString("base64url")].join(":");
+}
+
+export function decryptSecret(serializedCiphertext, key) {
+  const [version, ivEncoded, authTagEncoded, ciphertextEncoded] = serializedCiphertext.split(":");
+
+  if (version !== FORMAT_VERSION || !ivEncoded || !authTagEncoded || !ciphertextEncoded) {
+    throw new Error("Unsupported encrypted secret format.");
+  }
+
+  const decipher = createDecipheriv(ALGORITHM, key, Buffer.from(ivEncoded, "base64url"));
+  decipher.setAuthTag(Buffer.from(authTagEncoded, "base64url"));
+
+  const plaintext = Buffer.concat([
+    decipher.update(Buffer.from(ciphertextEncoded, "base64url")),
+    decipher.final()
+  ]);
+
+  return plaintext.toString("utf8");
+}

--- a/src/database.js
+++ b/src/database.js
@@ -1,0 +1,32 @@
+import { DatabaseSync } from "node:sqlite";
+import { mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+
+export function openDatabase(databasePath) {
+  mkdirSync(dirname(databasePath), { recursive: true });
+
+  const database = new DatabaseSync(databasePath);
+  database.exec(`
+    PRAGMA foreign_keys = ON;
+
+    CREATE TABLE IF NOT EXISTS monitors (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      url TEXT NOT NULL,
+      auth_type TEXT,
+      auth_username TEXT,
+      auth_secret_ciphertext TEXT,
+      created_at TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS notification_channels (
+      id TEXT PRIMARY KEY,
+      type TEXT NOT NULL,
+      destination TEXT NOT NULL,
+      credential_ciphertext TEXT NOT NULL,
+      created_at TEXT NOT NULL
+    );
+  `);
+
+  return database;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,14 @@
+import { createApp } from "./app.js";
+import { loadConfig } from "./config.js";
+import { openDatabase } from "./database.js";
+
+const config = loadConfig();
+const database = openDatabase(config.databasePath);
+const app = createApp({
+  database,
+  encryptionKey: config.encryptionKey
+});
+
+app.listen(config.port, () => {
+  process.stdout.write(`site-monitor listening on port ${config.port}\n`);
+});

--- a/src/repositories.js
+++ b/src/repositories.js
@@ -1,0 +1,164 @@
+import { randomUUID } from "node:crypto";
+
+import { encryptSecret } from "./crypto.js";
+
+export function createMonitorRepository(database, encryptionKey) {
+  const insertMonitor = database.prepare(`
+    INSERT INTO monitors (
+      id,
+      name,
+      url,
+      auth_type,
+      auth_username,
+      auth_secret_ciphertext,
+      created_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+  `);
+
+  const selectMonitor = database.prepare(`
+    SELECT
+      id,
+      name,
+      url,
+      auth_type,
+      auth_username,
+      auth_secret_ciphertext,
+      created_at
+    FROM monitors
+    WHERE id = ?
+  `);
+
+  return {
+    create(input) {
+      const id = randomUUID();
+      const createdAt = new Date().toISOString();
+      const auth = normalizeMonitorAuth(input.auth, encryptionKey);
+
+      insertMonitor.run(
+        id,
+        input.name,
+        input.url,
+        auth.type,
+        auth.username,
+        auth.secretCiphertext,
+        createdAt
+      );
+
+      return presentMonitor({
+        id,
+        name: input.name,
+        url: input.url,
+        auth_type: auth.type,
+        auth_username: auth.username,
+        auth_secret_ciphertext: auth.secretCiphertext,
+        created_at: createdAt
+      });
+    },
+
+    findById(id) {
+      const row = selectMonitor.get(id);
+      return row ? presentMonitor(row) : null;
+    }
+  };
+}
+
+export function createNotificationChannelRepository(database, encryptionKey) {
+  const insertChannel = database.prepare(`
+    INSERT INTO notification_channels (
+      id,
+      type,
+      destination,
+      credential_ciphertext,
+      created_at
+    ) VALUES (?, ?, ?, ?, ?)
+  `);
+
+  const selectChannel = database.prepare(`
+    SELECT
+      id,
+      type,
+      destination,
+      credential_ciphertext,
+      created_at
+    FROM notification_channels
+    WHERE id = ?
+  `);
+
+  return {
+    create(input) {
+      const id = randomUUID();
+      const createdAt = new Date().toISOString();
+
+      if (!input.credentials?.secret) {
+        throw new Error("Notification credentials.secret is required.");
+      }
+
+      const credentialCiphertext = encryptSecret(input.credentials.secret, encryptionKey);
+
+      insertChannel.run(id, input.type, input.destination, credentialCiphertext, createdAt);
+
+      return presentNotificationChannel({
+        id,
+        type: input.type,
+        destination: input.destination,
+        credential_ciphertext: credentialCiphertext,
+        created_at: createdAt
+      });
+    },
+
+    findById(id) {
+      const row = selectChannel.get(id);
+      return row ? presentNotificationChannel(row) : null;
+    }
+  };
+}
+
+function normalizeMonitorAuth(auth, encryptionKey) {
+  if (!auth) {
+    return {
+      type: null,
+      username: null,
+      secretCiphertext: null
+    };
+  }
+
+  if (!auth.type || !auth.secret) {
+    throw new Error("Monitor auth requires both type and secret.");
+  }
+
+  return {
+    type: auth.type,
+    username: auth.username ?? null,
+    secretCiphertext: encryptSecret(auth.secret, encryptionKey)
+  };
+}
+
+function presentMonitor(row) {
+  const hasSecret = Boolean(row.auth_secret_ciphertext);
+
+  return {
+    id: row.id,
+    name: row.name,
+    url: row.url,
+    createdAt: row.created_at,
+    auth: row.auth_type
+      ? {
+          type: row.auth_type,
+          username: row.auth_username,
+          secretConfigured: hasSecret
+        }
+      : null
+  };
+}
+
+function presentNotificationChannel(row) {
+  return {
+    id: row.id,
+    type: row.type,
+    destination: row.destination,
+    createdAt: row.created_at,
+    credentials: {
+      secretConfigured: Boolean(row.credential_ciphertext)
+    }
+  };
+}

--- a/test/secret-handling.integration.test.js
+++ b/test/secret-handling.integration.test.js
@@ -1,0 +1,147 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { once } from "node:events";
+import { randomBytes } from "node:crypto";
+
+import { createApp } from "../src/app.js";
+import { decryptSecret } from "../src/crypto.js";
+import { openDatabase } from "../src/database.js";
+
+test("monitor auth secrets are encrypted at rest and never returned after creation", async () => {
+  const harness = await createHarness();
+
+  try {
+    const createResponse = await fetch(`${harness.baseUrl}/api/monitors`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        name: "Checkout API",
+        url: "https://checkout.example.com/health",
+        auth: {
+          type: "basic",
+          username: "monitor-bot",
+          secret: "super-secret-password"
+        }
+      })
+    });
+
+    assert.equal(createResponse.status, 201);
+
+    const createdMonitor = await createResponse.json();
+    assert.deepEqual(createdMonitor.auth, {
+      type: "basic",
+      username: "monitor-bot",
+      secretConfigured: true
+    });
+    assert.equal(JSON.stringify(createdMonitor).includes("super-secret-password"), false);
+
+    const fetchResponse = await fetch(`${harness.baseUrl}/api/monitors/${createdMonitor.id}`);
+    assert.equal(fetchResponse.status, 200);
+
+    const storedMonitor = await fetchResponse.json();
+    assert.deepEqual(storedMonitor.auth, createdMonitor.auth);
+    assert.equal(JSON.stringify(storedMonitor).includes("super-secret-password"), false);
+
+    const monitorRow = harness.database
+      .prepare("SELECT auth_secret_ciphertext FROM monitors WHERE id = ?")
+      .get(createdMonitor.id);
+
+    assert.ok(monitorRow.auth_secret_ciphertext);
+    assert.notEqual(monitorRow.auth_secret_ciphertext, "super-secret-password");
+    assert.equal(decryptSecret(monitorRow.auth_secret_ciphertext, harness.encryptionKey), "super-secret-password");
+  } finally {
+    await harness.close();
+  }
+});
+
+test("notification credentials are encrypted at rest and never returned after creation", async () => {
+  const harness = await createHarness();
+
+  try {
+    const createResponse = await fetch(`${harness.baseUrl}/api/notification-channels`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        type: "webhook",
+        destination: "https://notify.example.com/hooks/site-monitor",
+        credentials: {
+          secret: "notify-token-123"
+        }
+      })
+    });
+
+    assert.equal(createResponse.status, 201);
+
+    const createdChannel = await createResponse.json();
+    assert.deepEqual(createdChannel.credentials, {
+      secretConfigured: true
+    });
+    assert.equal(JSON.stringify(createdChannel).includes("notify-token-123"), false);
+
+    const fetchResponse = await fetch(`${harness.baseUrl}/api/notification-channels/${createdChannel.id}`);
+    assert.equal(fetchResponse.status, 200);
+
+    const storedChannel = await fetchResponse.json();
+    assert.deepEqual(storedChannel.credentials, createdChannel.credentials);
+    assert.equal(JSON.stringify(storedChannel).includes("notify-token-123"), false);
+
+    const channelRow = harness.database
+      .prepare("SELECT credential_ciphertext FROM notification_channels WHERE id = ?")
+      .get(createdChannel.id);
+
+    assert.ok(channelRow.credential_ciphertext);
+    assert.notEqual(channelRow.credential_ciphertext, "notify-token-123");
+    assert.equal(decryptSecret(channelRow.credential_ciphertext, harness.encryptionKey), "notify-token-123");
+  } finally {
+    await harness.close();
+  }
+});
+
+async function createHarness() {
+  const directory = mkdtempSync(join(tmpdir(), "site-monitor-secret-test-"));
+  const databasePath = join(directory, "site-monitor.sqlite");
+  const database = openDatabase(databasePath);
+  const encryptionKey = randomBytes(32);
+  const app = createApp({
+    database,
+    encryptionKey
+  });
+
+  app.listen(0);
+  await once(app, "listening");
+
+  const address = app.address();
+
+  if (!address || typeof address === "string") {
+    throw new Error("Expected app to listen on an ephemeral TCP port.");
+  }
+
+  return {
+    app,
+    database,
+    directory,
+    encryptionKey,
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    async close() {
+      await new Promise((resolve, reject) => {
+        app.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+
+          resolve();
+        });
+      });
+      database.close();
+      rmSync(directory, { recursive: true, force: true });
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- implement a minimal Node + SQLite secret-handling slice for monitor auth and notification credentials
- encrypt secrets before persistence with AES-256-GCM and keep API responses redacted
- add integration tests and a focused security review note for NFR-005

## Advances
Advances #10.

## Tests
- npm test

## Reviewer Verify
- POST and GET monitor payloads never include the submitted auth secret in plaintext
- POST and GET notification channel payloads never include the submitted credential secret in plaintext
- persisted SQLite rows contain ciphertext instead of plaintext, as covered by the integration suite and security review note