### PR TITLE
Implement incident timeline and failure evidence view

### DIFF
--- a/docs/qa/traceability-matrix.md
+++ b/docs/qa/traceability-matrix.md
@@ -1,7 +1,7 @@
 # Traceability Matrix -- site-monitor
 
 > **Last updated:** 2026-04-06
-> **Updated by:** superiority-core
+> **Updated by:** superiority-developer
 
 ## Requirements Traceability
 
@@ -10,7 +10,7 @@
 | REQ-001 | As a reliability engineer, I want to create and manage monitors so that important sites and endpoints are checked automatically. | [#1](https://github.com/IDNTEQ/site-monitor/issues/1) |  | `` |  | Pending |
 | REQ-002 | As a reliability engineer, I want to configure alert policies and maintenance windows so that responders are notified only when failures are actionable. | [#2](https://github.com/IDNTEQ/site-monitor/issues/2) |  | `` |  | Pending |
 | REQ-003 | As an on-call responder, I want a dashboard of current monitor status and open incidents so that I can see what needs attention immediately. | [#3](https://github.com/IDNTEQ/site-monitor/issues/3) |  | `` |  | Pending |
-| REQ-004 | As an on-call responder, I want an incident timeline with failure evidence so that I can triage without searching raw logs elsewhere. | [#4](https://github.com/IDNTEQ/site-monitor/issues/4) |  | `` |  | Pending |
+| REQ-004 | As an on-call responder, I want an incident timeline with failure evidence so that I can triage without searching raw logs elsewhere. | [#4](https://github.com/IDNTEQ/site-monitor/issues/4) |  | `test/get-incident-detail.test.js:7`; `test/http.test.js:36` |  | Implemented |
 | REQ-005 | As an on-call responder, I want to acknowledge, mute, and resolve incidents so that the team has clear operational ownership during an outage. | [#5](https://github.com/IDNTEQ/site-monitor/issues/5) |  | `` |  | Pending |
 | NFR-001 | Detection latency | [#6](https://github.com/IDNTEQ/site-monitor/issues/6) |  | `` |  | Pending |
 | NFR-002 | Check execution reliability | [#7](https://github.com/IDNTEQ/site-monitor/issues/7) |  | `` |  | Pending |

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "site-monitor",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node src/index.js",
+    "test": "node --test"
+  }
+}

--- a/src/data/incident-fixtures.js
+++ b/src/data/incident-fixtures.js
@@ -1,0 +1,149 @@
+export const incidents = [
+  {
+    id: "inc-204",
+    state: "resolved",
+    openedAt: "2026-04-05T14:05:00Z",
+    acknowledgedAt: "2026-04-05T14:09:00Z",
+    resolvedAt: "2026-04-05T14:19:00Z",
+    affectedMonitor: {
+      id: "mon-checkout-prod",
+      name: "checkout-web",
+      environment: "production",
+      method: "GET",
+      url: "https://checkout.example.com/health",
+      expectedStatusRange: "200-299",
+      matchingRule: {
+        type: "keyword",
+        description: "Response body must contain checkout-ready"
+      }
+    },
+    checkResults: [
+      {
+        id: "chk-1",
+        checkedAt: "2026-04-05T14:03:00Z",
+        outcome: "failed",
+        statusCode: 503,
+        responseTimeMs: 1840,
+        errorClass: "UpstreamHttpError",
+        matchingRuleResult: "missing keyword"
+      },
+      {
+        id: "chk-2",
+        checkedAt: "2026-04-05T14:04:00Z",
+        outcome: "failed",
+        statusCode: 503,
+        responseTimeMs: 2012,
+        errorClass: "UpstreamHttpError",
+        matchingRuleResult: "missing keyword"
+      },
+      {
+        id: "chk-3",
+        checkedAt: "2026-04-05T14:05:00Z",
+        outcome: "failed",
+        statusCode: 503,
+        responseTimeMs: 2095,
+        errorClass: "ThresholdBreach",
+        matchingRuleResult: "missing keyword"
+      },
+      {
+        id: "chk-4",
+        checkedAt: "2026-04-05T14:11:00Z",
+        outcome: "failed",
+        statusCode: 502,
+        responseTimeMs: 1934,
+        errorClass: "UpstreamHttpError",
+        matchingRuleResult: "missing keyword"
+      },
+      {
+        id: "chk-5",
+        checkedAt: "2026-04-05T14:15:00Z",
+        outcome: "passed",
+        statusCode: 200,
+        responseTimeMs: 312,
+        errorClass: null,
+        matchingRuleResult: "matched keyword"
+      },
+      {
+        id: "chk-6",
+        checkedAt: "2026-04-05T14:16:00Z",
+        outcome: "passed",
+        statusCode: 200,
+        responseTimeMs: 298,
+        errorClass: null,
+        matchingRuleResult: "matched keyword"
+      }
+    ],
+    deliveryHistory: [
+      {
+        id: "del-1",
+        channel: "PagerDuty",
+        target: "web-primary",
+        status: "delivered",
+        deliveredAt: "2026-04-05T14:05:18Z",
+        detail: "Initial incident page sent to primary on-call schedule."
+      },
+      {
+        id: "del-2",
+        channel: "Slack",
+        target: "#site-monitor-alerts",
+        status: "delivered",
+        deliveredAt: "2026-04-05T14:05:34Z",
+        detail: "Failure evidence posted with latest check summary."
+      },
+      {
+        id: "del-3",
+        channel: "PagerDuty",
+        target: "web-primary",
+        status: "delivered",
+        deliveredAt: "2026-04-05T14:16:10Z",
+        detail: "Recovery notification sent after two passing checks."
+      }
+    ],
+    timeline: [
+      {
+        id: "evt-1",
+        type: "failure_started",
+        actor: "system",
+        createdAt: "2026-04-05T14:05:00Z",
+        summary: "Failure threshold reached after three consecutive failed checks."
+      },
+      {
+        id: "evt-2",
+        type: "notification_sent",
+        actor: "system",
+        createdAt: "2026-04-05T14:05:18Z",
+        summary: "PagerDuty delivery recorded for web-primary."
+      },
+      {
+        id: "evt-3",
+        type: "notification_sent",
+        actor: "system",
+        createdAt: "2026-04-05T14:05:34Z",
+        summary: "Slack delivery recorded for #site-monitor-alerts."
+      },
+      {
+        id: "evt-4",
+        type: "acknowledged",
+        actor: "Avery Chen",
+        createdAt: "2026-04-05T14:09:00Z",
+        summary: "Incident acknowledged by on-call responder.",
+        note: "Investigating elevated 503 responses from the checkout upstream."
+      },
+      {
+        id: "evt-5",
+        type: "recovered",
+        actor: "system",
+        createdAt: "2026-04-05T14:16:00Z",
+        summary: "Monitor recovered after two consecutive passing checks."
+      },
+      {
+        id: "evt-6",
+        type: "resolved",
+        actor: "Avery Chen",
+        createdAt: "2026-04-05T14:19:00Z",
+        summary: "Incident manually resolved after vendor mitigation verification.",
+        note: "Closed after confirming the upstream provider rollback."
+      }
+    ]
+  }
+];

--- a/src/http/create-server.js
+++ b/src/http/create-server.js
@@ -1,0 +1,94 @@
+import http from "node:http";
+
+import { IncidentRepository } from "../repositories/incident-repository.js";
+import { getIncidentDetail } from "../services/get-incident-detail.js";
+import { renderIncidentDetailPage } from "./render-incident-detail.js";
+
+function sendJson(response, statusCode, payload) {
+  response.writeHead(statusCode, {
+    "content-type": "application/json; charset=utf-8"
+  });
+  response.end(JSON.stringify(payload, null, 2));
+}
+
+function sendHtml(response, statusCode, html) {
+  response.writeHead(statusCode, {
+    "content-type": "text/html; charset=utf-8"
+  });
+  response.end(html);
+}
+
+function renderIndex(repository) {
+  const rows = repository
+    .listIncidents()
+    .map(
+      (incident) => `<li><a href="/incidents/${incident.id}">${incident.id}</a> · ${
+        incident.monitorName
+      } · ${incident.state} · ${incident.openedAt}</li>`
+    )
+    .join("");
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>site-monitor</title>
+  </head>
+  <body>
+    <h1>site-monitor</h1>
+    <p>Available incident details:</p>
+    <ul>${rows}</ul>
+  </body>
+</html>`;
+}
+
+export function createServer({ repository = new IncidentRepository() } = {}) {
+  return http.createServer(createRequestHandler({ repository }));
+}
+
+export function createRequestHandler({
+  repository = new IncidentRepository()
+} = {}) {
+  return (request, response) => {
+    const url = new URL(request.url, "http://127.0.0.1");
+
+    if (request.method !== "GET") {
+      sendJson(response, 405, { error: "method_not_allowed" });
+      return;
+    }
+
+    if (url.pathname === "/") {
+      sendHtml(response, 200, renderIndex(repository));
+      return;
+    }
+
+    if (url.pathname.startsWith("/api/incidents/")) {
+      const incidentId = url.pathname.slice("/api/incidents/".length);
+      const detail = getIncidentDetail(repository, incidentId);
+
+      if (!detail) {
+        sendJson(response, 404, { error: "incident_not_found" });
+        return;
+      }
+
+      sendJson(response, 200, detail);
+      return;
+    }
+
+    if (url.pathname.startsWith("/incidents/")) {
+      const incidentId = url.pathname.slice("/incidents/".length);
+      const detail = getIncidentDetail(repository, incidentId);
+
+      if (!detail) {
+        sendHtml(response, 404, "<h1>Incident not found</h1>");
+        return;
+      }
+
+      sendHtml(response, 200, renderIncidentDetailPage(detail));
+      return;
+    }
+
+    sendJson(response, 404, { error: "not_found" });
+  };
+}

--- a/src/http/render-incident-detail.js
+++ b/src/http/render-incident-detail.js
@@ -1,0 +1,446 @@
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function formatDate(value) {
+  return new Date(value).toISOString().replace(".000", "");
+}
+
+function renderCheckRows(checks) {
+  return checks
+    .map(
+      (check) => `
+        <tr>
+          <td>${escapeHtml(formatDate(check.checkedAt))}</td>
+          <td><span class="chip chip-${escapeHtml(check.outcome)}">${escapeHtml(check.outcome)}</span></td>
+          <td>${escapeHtml(check.statusCode)}</td>
+          <td>${escapeHtml(check.responseTimeMs)} ms</td>
+          <td>${escapeHtml(check.errorClass ?? "None")}</td>
+          <td>${escapeHtml(check.matchingRuleResult)}</td>
+        </tr>
+      `
+    )
+    .join("");
+}
+
+function renderDeliveryRows(deliveries) {
+  return deliveries
+    .map(
+      (delivery) => `
+        <tr>
+          <td>${escapeHtml(formatDate(delivery.deliveredAt))}</td>
+          <td>${escapeHtml(delivery.channel)}</td>
+          <td>${escapeHtml(delivery.target)}</td>
+          <td>${escapeHtml(delivery.status)}</td>
+          <td>${escapeHtml(delivery.detail)}</td>
+        </tr>
+      `
+    )
+    .join("");
+}
+
+function renderTimelineItems(timeline) {
+  return timeline
+    .map(
+      (event) => `
+        <li class="timeline-item">
+          <div class="timeline-meta">
+            <span class="timeline-label">${escapeHtml(event.label)}</span>
+            <time datetime="${escapeHtml(event.createdAt)}">${escapeHtml(
+              formatDate(event.createdAt)
+            )}</time>
+          </div>
+          <p class="timeline-summary">${escapeHtml(event.summary)}</p>
+          <p class="timeline-actor">Actor: ${escapeHtml(event.actor)}</p>
+          ${
+            event.note
+              ? `<p class="timeline-note">Note: ${escapeHtml(event.note)}</p>`
+              : ""
+          }
+        </li>
+      `
+    )
+    .join("");
+}
+
+export function renderIncidentDetailPage(detail) {
+  const { incident } = detail;
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Incident ${escapeHtml(incident.id)} | site-monitor</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --page: #f3efe5;
+        --panel: #fffdf8;
+        --ink: #172033;
+        --muted: #5c677d;
+        --line: #d5c8b0;
+        --accent: #b04b2f;
+        --accent-soft: #f5d4ca;
+        --ok: #2c7a4b;
+        --ok-soft: #dbefdf;
+        --bad: #a22b2b;
+        --bad-soft: #f8d7d7;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        font-family: "Iowan Old Style", "Palatino Linotype", serif;
+        color: var(--ink);
+        background:
+          radial-gradient(circle at top right, rgba(176, 75, 47, 0.16), transparent 28rem),
+          linear-gradient(180deg, #f6f1e7 0%, #efe6d6 100%);
+      }
+
+      main {
+        width: min(1100px, calc(100vw - 32px));
+        margin: 0 auto;
+        padding: 32px 0 48px;
+      }
+
+      .hero,
+      .panel {
+        background: var(--panel);
+        border: 1px solid var(--line);
+        border-radius: 24px;
+        box-shadow: 0 16px 40px rgba(23, 32, 51, 0.08);
+      }
+
+      .hero {
+        padding: 28px;
+        margin-bottom: 20px;
+      }
+
+      .hero-header {
+        display: flex;
+        justify-content: space-between;
+        gap: 16px;
+        align-items: start;
+      }
+
+      .eyebrow {
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        font-size: 0.78rem;
+        color: var(--muted);
+        margin: 0 0 8px;
+      }
+
+      h1, h2 {
+        margin: 0;
+      }
+
+      .status-pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 10px 14px;
+        border-radius: 999px;
+        background: var(--accent-soft);
+        color: var(--accent);
+        font-weight: 700;
+      }
+
+      .summary-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 12px;
+        margin-top: 22px;
+      }
+
+      .summary-card {
+        padding: 16px;
+        border-radius: 18px;
+        background: #f9f4ea;
+        border: 1px solid var(--line);
+      }
+
+      .summary-card strong,
+      .summary-card span {
+        display: block;
+      }
+
+      .summary-card strong {
+        font-size: 0.82rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--muted);
+        margin-bottom: 8px;
+      }
+
+      .layout {
+        display: grid;
+        grid-template-columns: minmax(0, 1.7fr) minmax(280px, 1fr);
+        gap: 20px;
+      }
+
+      .stack {
+        display: grid;
+        gap: 20px;
+      }
+
+      .panel {
+        padding: 22px;
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+        font-size: 0.96rem;
+      }
+
+      th,
+      td {
+        text-align: left;
+        padding: 12px 10px;
+        border-bottom: 1px solid #eadfcd;
+        vertical-align: top;
+      }
+
+      th {
+        font-size: 0.82rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--muted);
+      }
+
+      .chip {
+        display: inline-flex;
+        align-items: center;
+        border-radius: 999px;
+        padding: 4px 10px;
+        font-size: 0.82rem;
+        font-weight: 700;
+      }
+
+      .chip-passed {
+        color: var(--ok);
+        background: var(--ok-soft);
+      }
+
+      .chip-failed {
+        color: var(--bad);
+        background: var(--bad-soft);
+      }
+
+      .timeline {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: grid;
+        gap: 14px;
+      }
+
+      .timeline-item {
+        padding-left: 18px;
+        border-left: 3px solid var(--accent);
+      }
+
+      .timeline-meta {
+        display: flex;
+        justify-content: space-between;
+        gap: 16px;
+        font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+        font-size: 0.9rem;
+      }
+
+      .timeline-label {
+        font-weight: 700;
+      }
+
+      .timeline-summary,
+      .timeline-actor,
+      .timeline-note {
+        margin: 8px 0 0;
+        font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+      }
+
+      .monitor-meta {
+        display: grid;
+        gap: 10px;
+        font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+      }
+
+      .monitor-meta div {
+        padding-bottom: 10px;
+        border-bottom: 1px solid #eadfcd;
+      }
+
+      .monitor-meta strong {
+        display: block;
+        margin-bottom: 4px;
+        color: var(--muted);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-size: 0.8rem;
+      }
+
+      @media (max-width: 800px) {
+        main {
+          width: min(100vw - 20px, 100%);
+          padding-top: 18px;
+        }
+
+        .hero,
+        .panel {
+          border-radius: 18px;
+        }
+
+        .hero {
+          padding: 20px;
+        }
+
+        .hero-header,
+        .timeline-meta {
+          flex-direction: column;
+        }
+
+        .layout {
+          grid-template-columns: 1fr;
+        }
+
+        table,
+        thead,
+        tbody,
+        th,
+        td,
+        tr {
+          display: block;
+        }
+
+        thead {
+          display: none;
+        }
+
+        tr {
+          padding: 12px 0;
+          border-bottom: 1px solid #eadfcd;
+        }
+
+        td {
+          border: 0;
+          padding: 6px 0;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <section class="hero">
+        <p class="eyebrow">site-monitor incident detail</p>
+        <div class="hero-header">
+          <div>
+            <h1>Incident ${escapeHtml(incident.id)}</h1>
+            <p>${escapeHtml(incident.affectedMonitor.name)} in ${escapeHtml(
+              incident.affectedMonitor.environment
+            )}</p>
+          </div>
+          <span class="status-pill">${escapeHtml(incident.status)}</span>
+        </div>
+
+        <div class="summary-grid">
+          <div class="summary-card">
+            <strong>First failure</strong>
+            <span>${escapeHtml(formatDate(incident.firstFailureAt))}</span>
+          </div>
+          <div class="summary-card">
+            <strong>Opened</strong>
+            <span>${escapeHtml(formatDate(incident.openedAt))}</span>
+          </div>
+          <div class="summary-card">
+            <strong>Acknowledged</strong>
+            <span>${escapeHtml(formatDate(incident.acknowledgedAt))}</span>
+          </div>
+          <div class="summary-card">
+            <strong>Resolved</strong>
+            <span>${escapeHtml(formatDate(incident.resolvedAt))}</span>
+          </div>
+        </div>
+      </section>
+
+      <div class="layout">
+        <div class="stack">
+          <section class="panel">
+            <h2>Timeline</h2>
+            <ul class="timeline">${renderTimelineItems(detail.timeline)}</ul>
+          </section>
+
+          <section class="panel">
+            <h2>Latest Check Outcomes</h2>
+            <table>
+              <thead>
+                <tr>
+                  <th>Checked At</th>
+                  <th>Outcome</th>
+                  <th>Status Code</th>
+                  <th>Response Time</th>
+                  <th>Error Class</th>
+                  <th>Matching Rule</th>
+                </tr>
+              </thead>
+              <tbody>${renderCheckRows(detail.latestCheckOutcomes)}</tbody>
+            </table>
+          </section>
+        </div>
+
+        <div class="stack">
+          <section class="panel">
+            <h2>Affected Monitor</h2>
+            <div class="monitor-meta">
+              <div>
+                <strong>Monitor</strong>
+                <span>${escapeHtml(incident.affectedMonitor.name)}</span>
+              </div>
+              <div>
+                <strong>Endpoint</strong>
+                <span>${escapeHtml(incident.affectedMonitor.method)} ${escapeHtml(
+                  incident.affectedMonitor.url
+                )}</span>
+              </div>
+              <div>
+                <strong>Expected Status</strong>
+                <span>${escapeHtml(incident.affectedMonitor.expectedStatusRange)}</span>
+              </div>
+              <div>
+                <strong>Matching Rule</strong>
+                <span>${escapeHtml(incident.affectedMonitor.matchingRule.description)}</span>
+              </div>
+            </div>
+          </section>
+
+          <section class="panel">
+            <h2>Delivery History</h2>
+            <table>
+              <thead>
+                <tr>
+                  <th>Delivered At</th>
+                  <th>Channel</th>
+                  <th>Target</th>
+                  <th>Status</th>
+                  <th>Detail</th>
+                </tr>
+              </thead>
+              <tbody>${renderDeliveryRows(detail.deliveryHistory)}</tbody>
+            </table>
+          </section>
+        </div>
+      </div>
+    </main>
+  </body>
+</html>`;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,8 @@
+import { createServer } from "./http/create-server.js";
+
+const port = Number.parseInt(process.env.PORT ?? "3000", 10);
+const server = createServer();
+
+server.listen(port, () => {
+  process.stdout.write(`site-monitor listening on http://127.0.0.1:${port}\n`);
+});

--- a/src/repositories/incident-repository.js
+++ b/src/repositories/incident-repository.js
@@ -1,0 +1,16 @@
+import { incidents } from "../data/incident-fixtures.js";
+
+export class IncidentRepository {
+  findIncidentById(incidentId) {
+    return incidents.find((incident) => incident.id === incidentId) ?? null;
+  }
+
+  listIncidents() {
+    return incidents.map((incident) => ({
+      id: incident.id,
+      state: incident.state,
+      monitorName: incident.affectedMonitor.name,
+      openedAt: incident.openedAt
+    }));
+  }
+}

--- a/src/services/get-incident-detail.js
+++ b/src/services/get-incident-detail.js
@@ -1,0 +1,79 @@
+const TIMELINE_LABELS = {
+  failure_started: "Failure onset",
+  notification_sent: "Notification delivery",
+  acknowledged: "Acknowledged",
+  recovered: "Recovered",
+  resolved: "Manual resolution"
+};
+
+function sortDescendingByDate(records, field) {
+  return [...records].sort(
+    (left, right) => Date.parse(right[field]) - Date.parse(left[field])
+  );
+}
+
+function sortAscendingByDate(records, field) {
+  return [...records].sort(
+    (left, right) => Date.parse(left[field]) - Date.parse(right[field])
+  );
+}
+
+function getFirstFailureTime(checkResults) {
+  const failedChecks = checkResults.filter((result) => result.outcome === "failed");
+  if (failedChecks.length === 0) {
+    return null;
+  }
+
+  return sortAscendingByDate(failedChecks, "checkedAt")[0].checkedAt;
+}
+
+export function getIncidentDetail(repository, incidentId) {
+  const incident = repository.findIncidentById(incidentId);
+
+  if (!incident) {
+    return null;
+  }
+
+  return {
+    incident: {
+      id: incident.id,
+      status: incident.state,
+      openedAt: incident.openedAt,
+      acknowledgedAt: incident.acknowledgedAt,
+      resolvedAt: incident.resolvedAt,
+      firstFailureAt: getFirstFailureTime(incident.checkResults),
+      affectedMonitor: incident.affectedMonitor
+    },
+    latestCheckOutcomes: sortDescendingByDate(incident.checkResults, "checkedAt").map(
+      (result) => ({
+        id: result.id,
+        checkedAt: result.checkedAt,
+        outcome: result.outcome,
+        statusCode: result.statusCode,
+        responseTimeMs: result.responseTimeMs,
+        errorClass: result.errorClass,
+        matchingRuleResult: result.matchingRuleResult
+      })
+    ),
+    deliveryHistory: sortDescendingByDate(
+      incident.deliveryHistory,
+      "deliveredAt"
+    ).map((delivery) => ({
+      id: delivery.id,
+      channel: delivery.channel,
+      target: delivery.target,
+      status: delivery.status,
+      deliveredAt: delivery.deliveredAt,
+      detail: delivery.detail
+    })),
+    timeline: sortAscendingByDate(incident.timeline, "createdAt").map((event) => ({
+      id: event.id,
+      type: event.type,
+      label: TIMELINE_LABELS[event.type] ?? event.type,
+      actor: event.actor,
+      createdAt: event.createdAt,
+      summary: event.summary,
+      note: event.note ?? null
+    }))
+  };
+}

--- a/test/get-incident-detail.test.js
+++ b/test/get-incident-detail.test.js
@@ -1,0 +1,36 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { IncidentRepository } from "../src/repositories/incident-repository.js";
+import { getIncidentDetail } from "../src/services/get-incident-detail.js";
+
+test("getIncidentDetail returns incident evidence and ordered timeline data", () => {
+  const repository = new IncidentRepository();
+
+  const detail = getIncidentDetail(repository, "inc-204");
+
+  assert.ok(detail);
+  assert.equal(detail.incident.status, "resolved");
+  assert.equal(detail.incident.firstFailureAt, "2026-04-05T14:03:00Z");
+  assert.deepEqual(
+    detail.timeline.map((event) => event.label),
+    [
+      "Failure onset",
+      "Notification delivery",
+      "Notification delivery",
+      "Acknowledged",
+      "Recovered",
+      "Manual resolution"
+    ]
+  );
+  assert.equal(detail.latestCheckOutcomes[0].checkedAt, "2026-04-05T14:16:00Z");
+  assert.equal(detail.latestCheckOutcomes[0].matchingRuleResult, "matched keyword");
+  assert.equal(detail.deliveryHistory[0].channel, "PagerDuty");
+  assert.equal(detail.deliveryHistory[0].deliveredAt, "2026-04-05T14:16:10Z");
+});
+
+test("getIncidentDetail returns null for unknown incidents", () => {
+  const repository = new IncidentRepository();
+
+  assert.equal(getIncidentDetail(repository, "inc-missing"), null);
+});

--- a/test/http.test.js
+++ b/test/http.test.js
@@ -1,0 +1,66 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+
+import { createRequestHandler } from "../src/http/create-server.js";
+
+async function makeRequest(method, url) {
+  const handler = createRequestHandler();
+  const request = new EventEmitter();
+  request.method = method;
+  request.url = url;
+
+  let statusCode = null;
+  let headers = {};
+  let body = "";
+
+  const response = {
+    writeHead(code, nextHeaders) {
+      statusCode = code;
+      headers = nextHeaders;
+    },
+    end(chunk = "") {
+      body += chunk;
+    }
+  };
+
+  handler(request, response);
+
+  return {
+    statusCode,
+    headers,
+    body
+  };
+}
+
+test("GET /api/incidents/:incidentId returns incident detail JSON", async () => {
+  const response = await makeRequest("GET", "/api/incidents/inc-204");
+  const payload = JSON.parse(response.body);
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.headers["content-type"], "application/json; charset=utf-8");
+  assert.equal(payload.incident.affectedMonitor.name, "checkout-web");
+  assert.equal(payload.latestCheckOutcomes[1].statusCode, 200);
+  assert.equal(payload.latestCheckOutcomes[2].errorClass, "UpstreamHttpError");
+  assert.equal(payload.timeline[0].label, "Failure onset");
+});
+
+test("GET /incidents/:incidentId renders incident detail page with evidence sections", async () => {
+  const response = await makeRequest("GET", "/incidents/inc-204");
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.headers["content-type"], "text/html; charset=utf-8");
+  assert.match(response.body, /Latest Check Outcomes/);
+  assert.match(response.body, /Delivery History/);
+  assert.match(response.body, /Failure onset/);
+  assert.match(response.body, /Manual resolution/);
+  assert.match(response.body, /checkout\.example\.com\/health/);
+});
+
+test("GET /api/incidents/:incidentId returns 404 for unknown incidents", async () => {
+  const response = await makeRequest("GET", "/api/incidents/missing");
+  const payload = JSON.parse(response.body);
+
+  assert.equal(response.statusCode, 404);
+  assert.equal(payload.error, "incident_not_found");
+});


### PR DESCRIPTION
## Summary
- advance issue #4 with a minimal incident detail vertical slice
- add a JSON incident detail endpoint with monitor metadata, latest check outcomes, delivery history, and ordered timeline events
- add a rendered incident detail page that surfaces failure onset, acknowledgements, recoveries, and manual resolution evidence
- add focused tests and traceability coverage for REQ-004

## Reviewer Verify
- run npm test
- GET /api/incidents/inc-204 returns incident status, first failure time, latest check evidence, and delivery history
- GET /incidents/inc-204 shows the timeline labels Failure onset, Acknowledged, Recovered, and Manual resolution
- the incident detail page exposes status code, response time, error class, and matching rule result for recent checks

## Issue
- Advances #4
