### PR TITLE
Issue #7: add scheduled check reliability audit

### DIFF
--- a/docs/operations/check-execution-reliability.md
+++ b/docs/operations/check-execution-reliability.md
@@ -1,0 +1,56 @@
+# Check Execution Reliability
+
+This issue slice adds a narrow worker-facing audit flow for `NFR-002`:
+
+- capture scheduled check records with terminal completion outcomes
+- compute the seven-day completion ratio required by the PRD
+- render Prometheus-style worker metrics for staging verification
+
+## Audit Input
+
+The staging audit script expects a JSON file with this shape:
+
+```json
+{
+  "environment": "staging",
+  "windowStart": "2026-04-01T00:00:00.000Z",
+  "windowEnd": "2026-04-08T00:00:00.000Z",
+  "target": 0.99,
+  "records": [
+    {
+      "checkId": "check-1",
+      "monitorId": "homepage",
+      "scheduledAt": "2026-04-01T00:00:00.000Z",
+      "completedAt": "2026-04-01T00:00:30.000Z",
+      "outcome": "succeeded"
+    }
+  ]
+}
+```
+
+`records` should contain one item per scheduled check. A check counts as completed when it has `completedAt` and its `outcome` is a terminal worker outcome such as `succeeded`, `failed`, or `timeout`.
+
+## Running The Audit
+
+```bash
+npm run audit:staging-reliability -- ./path/to/staging-audit.json
+```
+
+Use `--format json` to emit machine-readable output:
+
+```bash
+node scripts/run-staging-reliability-audit.js ./path/to/staging-audit.json --format json
+```
+
+## Metrics
+
+The worker metrics renderer emits these top-level metrics:
+
+- `site_monitor_worker_scheduled_checks_total`
+- `site_monitor_worker_completed_checks_total`
+- `site_monitor_worker_missed_checks_total`
+- `site_monitor_worker_check_completion_ratio`
+- `site_monitor_worker_check_completion_target_ratio`
+- `site_monitor_worker_check_completion_target_met`
+
+Per-monitor counts and ratios are also exported with `monitor_id` labels so staging soak audits can isolate unreliable monitors without changing the aggregate target calculation.

--- a/docs/qa/traceability-matrix.md
+++ b/docs/qa/traceability-matrix.md
@@ -13,7 +13,7 @@
 | REQ-004 | As an on-call responder, I want an incident timeline with failure evidence so that I can triage without searching raw logs elsewhere. | [#4](https://github.com/IDNTEQ/site-monitor/issues/4) |  | `` |  | Pending |
 | REQ-005 | As an on-call responder, I want to acknowledge, mute, and resolve incidents so that the team has clear operational ownership during an outage. | [#5](https://github.com/IDNTEQ/site-monitor/issues/5) |  | `` |  | Pending |
 | NFR-001 | Detection latency | [#6](https://github.com/IDNTEQ/site-monitor/issues/6) |  | `` |  | Pending |
-| NFR-002 | Check execution reliability | [#7](https://github.com/IDNTEQ/site-monitor/issues/7) |  | `src/worker/reliability/checkExecutionReliability.test.js` | `docs/operations/check-execution-reliability.md` | In Progress |
+| NFR-002 | Check execution reliability | [#7](https://github.com/IDNTEQ/site-monitor/issues/7) | [#17](https://github.com/IDNTEQ/site-monitor/pull/17) | `src/worker/reliability/checkExecutionReliability.test.js:28` | `docs/operations/check-execution-reliability.md` | Needs Review |
 | NFR-003 | Dashboard load time | [#8](https://github.com/IDNTEQ/site-monitor/issues/8) |  | `` |  | Pending |
 | NFR-004 | Accessibility | [#9](https://github.com/IDNTEQ/site-monitor/issues/9) |  | `` |  | Pending |
 | NFR-005 | Secret handling | [#10](https://github.com/IDNTEQ/site-monitor/issues/10) |  | `` |  | Pending |

--- a/docs/qa/traceability-matrix.md
+++ b/docs/qa/traceability-matrix.md
@@ -13,7 +13,7 @@
 | REQ-004 | As an on-call responder, I want an incident timeline with failure evidence so that I can triage without searching raw logs elsewhere. | [#4](https://github.com/IDNTEQ/site-monitor/issues/4) |  | `` |  | Pending |
 | REQ-005 | As an on-call responder, I want to acknowledge, mute, and resolve incidents so that the team has clear operational ownership during an outage. | [#5](https://github.com/IDNTEQ/site-monitor/issues/5) |  | `` |  | Pending |
 | NFR-001 | Detection latency | [#6](https://github.com/IDNTEQ/site-monitor/issues/6) |  | `` |  | Pending |
-| NFR-002 | Check execution reliability | [#7](https://github.com/IDNTEQ/site-monitor/issues/7) |  | `` |  | Pending |
+| NFR-002 | Check execution reliability | [#7](https://github.com/IDNTEQ/site-monitor/issues/7) |  | `src/worker/reliability/checkExecutionReliability.test.js` | `docs/operations/check-execution-reliability.md` | In Progress |
 | NFR-003 | Dashboard load time | [#8](https://github.com/IDNTEQ/site-monitor/issues/8) |  | `` |  | Pending |
 | NFR-004 | Accessibility | [#9](https://github.com/IDNTEQ/site-monitor/issues/9) |  | `` |  | Pending |
 | NFR-005 | Secret handling | [#10](https://github.com/IDNTEQ/site-monitor/issues/10) |  | `` |  | Pending |

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "site-monitor",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test",
+    "audit:staging-reliability": "node scripts/run-staging-reliability-audit.js"
+  }
+}

--- a/scripts/run-staging-reliability-audit.js
+++ b/scripts/run-staging-reliability-audit.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import process from "node:process";
+
+import {
+  createStagingReliabilityAudit,
+  formatTextAuditReport
+} from "../src/worker/reliability/stagingReliabilityAudit.js";
+
+function printUsage() {
+  console.error("Usage: node scripts/run-staging-reliability-audit.js <audit.json> [--format json]");
+}
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const jsonFormat = args.includes("--format") && args[args.indexOf("--format") + 1] === "json";
+  const path = args.find((argument) => !argument.startsWith("--"));
+
+  if (!path) {
+    printUsage();
+    process.exit(1);
+  }
+
+  return {
+    path,
+    format: jsonFormat ? "json" : "text"
+  };
+}
+
+function main() {
+  const { path, format } = parseArgs(process.argv);
+  const rawInput = readFileSync(path, "utf8");
+  const payload = JSON.parse(rawInput);
+  const report = createStagingReliabilityAudit(payload);
+
+  if (format === "json") {
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    return;
+  }
+
+  process.stdout.write(`${formatTextAuditReport(report)}\n`);
+}
+
+main();

--- a/src/worker/reliability/checkExecutionReliability.js
+++ b/src/worker/reliability/checkExecutionReliability.js
@@ -1,0 +1,194 @@
+const DEFAULT_TARGET = 0.99;
+const TERMINAL_OUTCOMES = new Set([
+  "succeeded",
+  "failed",
+  "timeout",
+  "dns_error",
+  "tls_error",
+  "connection_error",
+  "http_error"
+]);
+
+function parseTimestamp(value, fieldName) {
+  const timestamp = Date.parse(value);
+
+  if (Number.isNaN(timestamp)) {
+    throw new Error(`Expected ${fieldName} to be an ISO-8601 timestamp. Received: ${value}`);
+  }
+
+  return timestamp;
+}
+
+function normalizeRecord(record) {
+  if (!record || typeof record !== "object") {
+    throw new Error("Expected each reliability record to be an object.");
+  }
+
+  if (!record.checkId) {
+    throw new Error("Expected reliability records to include checkId.");
+  }
+
+  if (!record.monitorId) {
+    throw new Error("Expected reliability records to include monitorId.");
+  }
+
+  if (!record.scheduledAt) {
+    throw new Error("Expected reliability records to include scheduledAt.");
+  }
+
+  return {
+    checkId: String(record.checkId),
+    monitorId: String(record.monitorId),
+    scheduledAt: String(record.scheduledAt),
+    completedAt: record.completedAt ? String(record.completedAt) : null,
+    outcome: record.outcome ? String(record.outcome) : null
+  };
+}
+
+function didCheckComplete(record) {
+  if (!record.completedAt) {
+    return false;
+  }
+
+  if (!record.outcome) {
+    return true;
+  }
+
+  return TERMINAL_OUTCOMES.has(record.outcome);
+}
+
+function roundRatio(value) {
+  return Number(value.toFixed(6));
+}
+
+function toMetricLabels(labels) {
+  const serialized = Object.entries(labels)
+    .filter(([, value]) => value !== undefined && value !== null && value !== "")
+    .map(([key, value]) => `${key}="${String(value).replaceAll("\"", "\\\"")}"`);
+
+  return serialized.length === 0 ? "" : `{${serialized.join(",")}}`;
+}
+
+function formatMetric(name, value, labels = {}) {
+  return `${name}${toMetricLabels(labels)} ${value}`;
+}
+
+function createMonitorSummary(records, target) {
+  const scheduledChecks = records.length;
+  const completedChecks = records.filter(didCheckComplete).length;
+  const missedChecks = scheduledChecks - completedChecks;
+  const completionRate = scheduledChecks === 0 ? 0 : completedChecks / scheduledChecks;
+
+  return {
+    monitorId: records[0]?.monitorId ?? "unknown",
+    scheduledChecks,
+    completedChecks,
+    missedChecks,
+    completionRate: roundRatio(completionRate),
+    meetsTarget: scheduledChecks > 0 && completionRate >= target
+  };
+}
+
+export function summarizeCheckExecutionReliability(records, options) {
+  if (!Array.isArray(records)) {
+    throw new Error("Expected records to be an array.");
+  }
+
+  if (!options || typeof options !== "object") {
+    throw new Error("Expected options to include windowStart and windowEnd.");
+  }
+
+  const target = options.target ?? DEFAULT_TARGET;
+
+  if (typeof target !== "number" || !Number.isFinite(target) || target <= 0 || target > 1) {
+    throw new Error("Expected target to be a number between 0 and 1.");
+  }
+
+  const windowStart = parseTimestamp(options.windowStart, "windowStart");
+  const windowEnd = parseTimestamp(options.windowEnd, "windowEnd");
+
+  if (windowStart >= windowEnd) {
+    throw new Error("Expected windowStart to be earlier than windowEnd.");
+  }
+
+  const normalizedRecords = records
+    .map(normalizeRecord)
+    .map((record) => ({
+      ...record,
+      scheduledAtMs: parseTimestamp(record.scheduledAt, "scheduledAt"),
+      completedAtMs: record.completedAt ? parseTimestamp(record.completedAt, "completedAt") : null
+    }))
+    .filter((record) => record.scheduledAtMs >= windowStart && record.scheduledAtMs < windowEnd)
+    .sort((left, right) => left.scheduledAtMs - right.scheduledAtMs);
+
+  const scheduledChecks = normalizedRecords.length;
+  const completedChecks = normalizedRecords.filter(didCheckComplete).length;
+  const missedChecks = scheduledChecks - completedChecks;
+  const completionRate = scheduledChecks === 0 ? 0 : completedChecks / scheduledChecks;
+  const allowedMisses = Math.floor(scheduledChecks * (1 - target));
+  const monitorGroups = new Map();
+
+  for (const record of normalizedRecords) {
+    const existing = monitorGroups.get(record.monitorId) ?? [];
+    existing.push(record);
+    monitorGroups.set(record.monitorId, existing);
+  }
+
+  const monitorSummaries = [...monitorGroups.values()]
+    .map((monitorRecords) => createMonitorSummary(monitorRecords, target))
+    .sort((left, right) => left.monitorId.localeCompare(right.monitorId));
+
+  return {
+    windowStart: new Date(windowStart).toISOString(),
+    windowEnd: new Date(windowEnd).toISOString(),
+    target: roundRatio(target),
+    scheduledChecks,
+    completedChecks,
+    missedChecks,
+    allowedMisses,
+    errorBudgetRemaining: allowedMisses - missedChecks,
+    completionRate: roundRatio(completionRate),
+    completionPercent: roundRatio(completionRate * 100),
+    meetsTarget: scheduledChecks > 0 && completionRate >= target,
+    monitorSummaries
+  };
+}
+
+export function renderCheckExecutionMetrics(summary, labels = {}) {
+  if (!summary || typeof summary !== "object") {
+    throw new Error("Expected summary to be an object.");
+  }
+
+  const lines = [
+    "# HELP site_monitor_worker_scheduled_checks_total Scheduled checks seen in the audit window.",
+    "# TYPE site_monitor_worker_scheduled_checks_total counter",
+    formatMetric("site_monitor_worker_scheduled_checks_total", summary.scheduledChecks, labels),
+    "# HELP site_monitor_worker_completed_checks_total Scheduled checks that reached a terminal outcome.",
+    "# TYPE site_monitor_worker_completed_checks_total counter",
+    formatMetric("site_monitor_worker_completed_checks_total", summary.completedChecks, labels),
+    "# HELP site_monitor_worker_missed_checks_total Scheduled checks missing a terminal completion record.",
+    "# TYPE site_monitor_worker_missed_checks_total counter",
+    formatMetric("site_monitor_worker_missed_checks_total", summary.missedChecks, labels),
+    "# HELP site_monitor_worker_check_completion_ratio Completion ratio for scheduled checks in the audit window.",
+    "# TYPE site_monitor_worker_check_completion_ratio gauge",
+    formatMetric("site_monitor_worker_check_completion_ratio", summary.completionRate, labels),
+    "# HELP site_monitor_worker_check_completion_target_ratio Required completion ratio for reliability compliance.",
+    "# TYPE site_monitor_worker_check_completion_target_ratio gauge",
+    formatMetric("site_monitor_worker_check_completion_target_ratio", summary.target, labels),
+    "# HELP site_monitor_worker_check_completion_target_met Whether the completion ratio meets the reliability target.",
+    "# TYPE site_monitor_worker_check_completion_target_met gauge",
+    formatMetric("site_monitor_worker_check_completion_target_met", summary.meetsTarget ? 1 : 0, labels)
+  ];
+
+  for (const monitorSummary of summary.monitorSummaries ?? []) {
+    const monitorLabels = { ...labels, monitor_id: monitorSummary.monitorId };
+    lines.push(
+      formatMetric("site_monitor_worker_monitor_scheduled_checks_total", monitorSummary.scheduledChecks, monitorLabels),
+      formatMetric("site_monitor_worker_monitor_completed_checks_total", monitorSummary.completedChecks, monitorLabels),
+      formatMetric("site_monitor_worker_monitor_missed_checks_total", monitorSummary.missedChecks, monitorLabels),
+      formatMetric("site_monitor_worker_monitor_check_completion_ratio", monitorSummary.completionRate, monitorLabels)
+    );
+  }
+
+  return `${lines.join("\n")}\n`;
+}

--- a/src/worker/reliability/checkExecutionReliability.test.js
+++ b/src/worker/reliability/checkExecutionReliability.test.js
@@ -1,0 +1,106 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import {
+  renderCheckExecutionMetrics,
+  summarizeCheckExecutionReliability
+} from "./checkExecutionReliability.js";
+import {
+  createStagingReliabilityAudit,
+  formatTextAuditReport
+} from "./stagingReliabilityAudit.js";
+
+function buildRecord(index, overrides = {}) {
+  const scheduledAt = new Date(Date.UTC(2026, 3, 1, 0, index, 0)).toISOString();
+  const completedAt = new Date(Date.UTC(2026, 3, 1, 0, index, 30)).toISOString();
+
+  return {
+    checkId: `check-${index}`,
+    monitorId: index % 2 === 0 ? "api" : "web",
+    scheduledAt,
+    completedAt,
+    outcome: "succeeded",
+    ...overrides
+  };
+}
+
+test("summarizeCheckExecutionReliability passes when 99 percent of checks complete", () => {
+  const records = Array.from({ length: 100 }, (_, index) =>
+    buildRecord(index, index === 99 ? { completedAt: null, outcome: null } : {})
+  );
+
+  const summary = summarizeCheckExecutionReliability(records, {
+    windowStart: "2026-04-01T00:00:00.000Z",
+    windowEnd: "2026-04-08T00:00:00.000Z"
+  });
+
+  assert.equal(summary.scheduledChecks, 100);
+  assert.equal(summary.completedChecks, 99);
+  assert.equal(summary.missedChecks, 1);
+  assert.equal(summary.allowedMisses, 1);
+  assert.equal(summary.completionRate, 0.99);
+  assert.equal(summary.meetsTarget, true);
+});
+
+test("summarizeCheckExecutionReliability fails when the completion rate drops below the target", () => {
+  const records = Array.from({ length: 100 }, (_, index) =>
+    buildRecord(index, index >= 98 ? { completedAt: null, outcome: null } : {})
+  );
+
+  const summary = summarizeCheckExecutionReliability(records, {
+    windowStart: "2026-04-01T00:00:00.000Z",
+    windowEnd: "2026-04-08T00:00:00.000Z"
+  });
+
+  assert.equal(summary.completedChecks, 98);
+  assert.equal(summary.missedChecks, 2);
+  assert.equal(summary.meetsTarget, false);
+  assert.equal(summary.errorBudgetRemaining, -1);
+});
+
+test("summarizeCheckExecutionReliability excludes checks scheduled outside the audit window", () => {
+  const records = [
+    buildRecord(1, { scheduledAt: "2026-03-31T23:59:59.000Z" }),
+    buildRecord(2),
+    buildRecord(3)
+  ];
+
+  const summary = summarizeCheckExecutionReliability(records, {
+    windowStart: "2026-04-01T00:00:00.000Z",
+    windowEnd: "2026-04-08T00:00:00.000Z"
+  });
+
+  assert.equal(summary.scheduledChecks, 2);
+  assert.equal(summary.completedChecks, 2);
+});
+
+test("renderCheckExecutionMetrics emits Prometheus metrics for totals and per-monitor breakdowns", () => {
+  const summary = summarizeCheckExecutionReliability([buildRecord(1), buildRecord(2)], {
+    windowStart: "2026-04-01T00:00:00.000Z",
+    windowEnd: "2026-04-08T00:00:00.000Z"
+  });
+
+  const metrics = renderCheckExecutionMetrics(summary, { environment: "staging" });
+
+  assert.match(metrics, /site_monitor_worker_scheduled_checks_total\{environment="staging"\} 2/);
+  assert.match(metrics, /site_monitor_worker_check_completion_ratio\{environment="staging"\} 1/);
+  assert.match(
+    metrics,
+    /site_monitor_worker_monitor_scheduled_checks_total\{environment="staging",monitor_id="api"\} 1/
+  );
+});
+
+test("createStagingReliabilityAudit builds a machine-readable report and text summary", () => {
+  const fixturePath = new URL("./stagingReliabilityAudit.fixture.json", import.meta.url);
+  const payload = JSON.parse(readFileSync(fixturePath, "utf8"));
+  const report = createStagingReliabilityAudit(payload);
+  const textReport = formatTextAuditReport(report);
+
+  assert.equal(report.environment, "staging");
+  assert.equal(report.summary.scheduledChecks, 2);
+  assert.equal(report.summary.completedChecks, 1);
+  assert.equal(report.summary.meetsTarget, false);
+  assert.match(textReport, /Check execution reliability audit/);
+  assert.match(textReport, /Target met: no/);
+});

--- a/src/worker/reliability/stagingReliabilityAudit.fixture.json
+++ b/src/worker/reliability/stagingReliabilityAudit.fixture.json
@@ -1,0 +1,21 @@
+{
+  "environment": "staging",
+  "windowStart": "2026-04-01T00:00:00.000Z",
+  "windowEnd": "2026-04-08T00:00:00.000Z",
+  "records": [
+    {
+      "checkId": "check-1",
+      "monitorId": "web",
+      "scheduledAt": "2026-04-01T00:01:00.000Z",
+      "completedAt": "2026-04-01T00:01:30.000Z",
+      "outcome": "succeeded"
+    },
+    {
+      "checkId": "check-2",
+      "monitorId": "api",
+      "scheduledAt": "2026-04-01T00:02:00.000Z",
+      "completedAt": null,
+      "outcome": null
+    }
+  ]
+}

--- a/src/worker/reliability/stagingReliabilityAudit.js
+++ b/src/worker/reliability/stagingReliabilityAudit.js
@@ -1,0 +1,53 @@
+import {
+  renderCheckExecutionMetrics,
+  summarizeCheckExecutionReliability
+} from "./checkExecutionReliability.js";
+
+function formatMonitorLine(monitorSummary) {
+  return [
+    `- ${monitorSummary.monitorId}`,
+    `${monitorSummary.completedChecks}/${monitorSummary.scheduledChecks} completed`,
+    `${monitorSummary.completionRate.toFixed(4)} ratio`
+  ].join(" | ");
+}
+
+export function createStagingReliabilityAudit(payload) {
+  const environment = payload.environment ?? "staging";
+  const summary = summarizeCheckExecutionReliability(payload.records ?? [], {
+    windowStart: payload.windowStart,
+    windowEnd: payload.windowEnd,
+    target: payload.target
+  });
+  const metrics = renderCheckExecutionMetrics(summary, { environment });
+
+  return {
+    environment,
+    summary,
+    metrics
+  };
+}
+
+export function formatTextAuditReport(report) {
+  const monitorLines = report.summary.monitorSummaries.length === 0
+    ? ["- none"]
+    : report.summary.monitorSummaries.map(formatMonitorLine);
+
+  return [
+    "Check execution reliability audit",
+    `Environment: ${report.environment}`,
+    `Window: ${report.summary.windowStart} -> ${report.summary.windowEnd}`,
+    `Scheduled checks: ${report.summary.scheduledChecks}`,
+    `Completed checks: ${report.summary.completedChecks}`,
+    `Missed checks: ${report.summary.missedChecks}`,
+    `Completion rate: ${report.summary.completionPercent.toFixed(2)}%`,
+    `Target: ${(report.summary.target * 100).toFixed(2)}%`,
+    `Target met: ${report.summary.meetsTarget ? "yes" : "no"}`,
+    `Allowed misses: ${report.summary.allowedMisses}`,
+    `Error budget remaining: ${report.summary.errorBudgetRemaining}`,
+    "Per-monitor breakdown:",
+    ...monitorLines,
+    "",
+    "Prometheus metrics:",
+    report.metrics.trimEnd()
+  ].join("\n");
+}


### PR DESCRIPTION
## Summary
- add a worker reliability module that calculates scheduled-vs-completed check ratios for a 7-day audit window
- emit Prometheus-style worker metrics and per-monitor breakdowns for staging soak verification
- add a staging audit CLI, focused tests, and traceability and ops documentation for NFR-002

## Reviewer Verify
- run npm test
- run node scripts/run-staging-reliability-audit.js src/worker/reliability/stagingReliabilityAudit.fixture.json --format json
- confirm the report exposes scheduledChecks, completedChecks, missedChecks, completionRate, and meetsTarget
- confirm the metrics output includes the aggregate worker gauges plus per-monitor labeled metrics

## Issue
- advances #7