### PR TITLE
Implement NFR-006 auditability retention slice

### DIFF
--- a/docs/qa/traceability-matrix.md
+++ b/docs/qa/traceability-matrix.md
@@ -1,7 +1,7 @@
 # Traceability Matrix -- site-monitor
 
 > **Last updated:** 2026-04-06
-> **Updated by:** superiority-core
+> **Updated by:** superiority-developer
 
 ## Requirements Traceability
 
@@ -17,5 +17,5 @@
 | NFR-003 | Dashboard load time | [#8](https://github.com/IDNTEQ/site-monitor/issues/8) |  | `` |  | Pending |
 | NFR-004 | Accessibility | [#9](https://github.com/IDNTEQ/site-monitor/issues/9) |  | `` |  | Pending |
 | NFR-005 | Secret handling | [#10](https://github.com/IDNTEQ/site-monitor/issues/10) |  | `` |  | Pending |
-| NFR-006 | Auditability | [#11](https://github.com/IDNTEQ/site-monitor/issues/11) |  | `` |  | Pending |
+| NFR-006 | Auditability | [#11](https://github.com/IDNTEQ/site-monitor/issues/11) |  | `test/auditability.test.js:7`, `test/auditability.test.js:66` |  | Needs Review |
 | NFR-007 | Mobile support | [#12](https://github.com/IDNTEQ/site-monitor/issues/12) |  | `` |  | Pending |

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "site-monitor",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Minimal auditability slice for incident actions and policy changes.",
+  "scripts": {
+    "start": "node src/server.js",
+    "test": "node --test"
+  }
+}

--- a/src/audit-store.js
+++ b/src/audit-store.js
@@ -1,0 +1,279 @@
+const { randomUUID } = require('node:crypto');
+const { DatabaseSync } = require('node:sqlite');
+
+const RETENTION_DAYS = 90;
+
+class AuditStore {
+  constructor(options = {}) {
+    const dbPath = options.dbPath ?? ':memory:';
+
+    this.db = new DatabaseSync(dbPath);
+    this.db.exec(`
+      PRAGMA foreign_keys = ON;
+
+      CREATE TABLE IF NOT EXISTS incident_action_audits (
+        id TEXT PRIMARY KEY,
+        incident_id TEXT NOT NULL,
+        action_type TEXT NOT NULL,
+        actor TEXT NOT NULL,
+        note TEXT NOT NULL DEFAULT '',
+        created_at TEXT NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS policy_change_audits (
+        id TEXT PRIMARY KEY,
+        policy_id TEXT NOT NULL,
+        change_type TEXT NOT NULL,
+        actor TEXT NOT NULL,
+        summary TEXT NOT NULL,
+        before_value TEXT,
+        after_value TEXT,
+        created_at TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS incident_action_audits_incident_created_idx
+        ON incident_action_audits (incident_id, created_at DESC);
+
+      CREATE INDEX IF NOT EXISTS policy_change_audits_policy_created_idx
+        ON policy_change_audits (policy_id, created_at DESC);
+    `);
+  }
+
+  close() {
+    this.db.close();
+  }
+
+  recordIncidentAction(input) {
+    const id = randomUUID();
+    const incidentId = requireNonEmptyString(input.incidentId, 'incidentId');
+    const actionType = requireNonEmptyString(input.actionType, 'actionType');
+    const actor = requireNonEmptyString(input.actor, 'actor');
+    const note = optionalString(input.note, 'note');
+    const createdAt = normalizeTimestamp(input.occurredAt);
+
+    this.db
+      .prepare(`
+        INSERT INTO incident_action_audits (
+          id,
+          incident_id,
+          action_type,
+          actor,
+          note,
+          created_at
+        ) VALUES (?, ?, ?, ?, ?, ?)
+      `)
+      .run(id, incidentId, actionType, actor, note, createdAt);
+
+    return this.getIncidentAction(id);
+  }
+
+  listIncidentActions(incidentId) {
+    requireNonEmptyString(incidentId, 'incidentId');
+
+    const rows = this.db
+      .prepare(`
+        SELECT
+          id,
+          incident_id,
+          action_type,
+          actor,
+          note,
+          created_at
+        FROM incident_action_audits
+        WHERE incident_id = ?
+        ORDER BY created_at DESC, id DESC
+      `)
+      .all(incidentId);
+
+    return rows.map(mapIncidentActionRow);
+  }
+
+  recordPolicyChange(input) {
+    const id = randomUUID();
+    const policyId = requireNonEmptyString(input.policyId, 'policyId');
+    const changeType = requireNonEmptyString(input.changeType, 'changeType');
+    const actor = requireNonEmptyString(input.actor, 'actor');
+    const summary = requireNonEmptyString(input.summary, 'summary');
+    const beforeValue = optionalJson(input.before);
+    const afterValue = optionalJson(input.after);
+    const createdAt = normalizeTimestamp(input.occurredAt);
+
+    this.db
+      .prepare(`
+        INSERT INTO policy_change_audits (
+          id,
+          policy_id,
+          change_type,
+          actor,
+          summary,
+          before_value,
+          after_value,
+          created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      `)
+      .run(id, policyId, changeType, actor, summary, beforeValue, afterValue, createdAt);
+
+    return this.getPolicyChange(id);
+  }
+
+  listPolicyChanges(policyId) {
+    requireNonEmptyString(policyId, 'policyId');
+
+    const rows = this.db
+      .prepare(`
+        SELECT
+          id,
+          policy_id,
+          change_type,
+          actor,
+          summary,
+          before_value,
+          after_value,
+          created_at
+        FROM policy_change_audits
+        WHERE policy_id = ?
+        ORDER BY created_at DESC, id DESC
+      `)
+      .all(policyId);
+
+    return rows.map(mapPolicyChangeRow);
+  }
+
+  purgeExpiredRecords(options = {}) {
+    const referenceTime = normalizeTimestamp(options.referenceTime);
+
+    const deleteIncidentActions = this.db
+      .prepare(`
+        DELETE FROM incident_action_audits
+        WHERE julianday(created_at) < julianday(?) - ?
+      `)
+      .run(referenceTime, RETENTION_DAYS);
+
+    const deletePolicyChanges = this.db
+      .prepare(`
+        DELETE FROM policy_change_audits
+        WHERE julianday(created_at) < julianday(?) - ?
+      `)
+      .run(referenceTime, RETENTION_DAYS);
+
+    return {
+      referenceTime,
+      retentionDays: RETENTION_DAYS,
+      incidentActionsDeleted: deleteIncidentActions.changes,
+      policyChangesDeleted: deletePolicyChanges.changes
+    };
+  }
+
+  getIncidentAction(id) {
+    const row = this.db
+      .prepare(`
+        SELECT
+          id,
+          incident_id,
+          action_type,
+          actor,
+          note,
+          created_at
+        FROM incident_action_audits
+        WHERE id = ?
+      `)
+      .get(id);
+
+    return row ? mapIncidentActionRow(row) : null;
+  }
+
+  getPolicyChange(id) {
+    const row = this.db
+      .prepare(`
+        SELECT
+          id,
+          policy_id,
+          change_type,
+          actor,
+          summary,
+          before_value,
+          after_value,
+          created_at
+        FROM policy_change_audits
+        WHERE id = ?
+      `)
+      .get(id);
+
+    return row ? mapPolicyChangeRow(row) : null;
+  }
+}
+
+function mapIncidentActionRow(row) {
+  return {
+    id: row.id,
+    incidentId: row.incident_id,
+    actionType: row.action_type,
+    actor: row.actor,
+    note: row.note,
+    occurredAt: row.created_at
+  };
+}
+
+function mapPolicyChangeRow(row) {
+  return {
+    id: row.id,
+    policyId: row.policy_id,
+    changeType: row.change_type,
+    actor: row.actor,
+    summary: row.summary,
+    before: parseJson(row.before_value),
+    after: parseJson(row.after_value),
+    occurredAt: row.created_at
+  };
+}
+
+function requireNonEmptyString(value, fieldName) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`${fieldName} must be a non-empty string`);
+  }
+
+  return value.trim();
+}
+
+function optionalString(value, fieldName) {
+  if (value === undefined) {
+    return '';
+  }
+
+  if (typeof value !== 'string') {
+    throw new Error(`${fieldName} must be a string when provided`);
+  }
+
+  return value;
+}
+
+function optionalJson(value) {
+  if (value === undefined) {
+    return null;
+  }
+
+  return JSON.stringify(value);
+}
+
+function parseJson(value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  return JSON.parse(value);
+}
+
+function normalizeTimestamp(value) {
+  const date = value === undefined ? new Date() : new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    throw new Error('occurredAt/referenceTime must be a valid ISO-8601 timestamp');
+  }
+
+  return date.toISOString();
+}
+
+module.exports = {
+  AuditStore,
+  RETENTION_DAYS
+};

--- a/src/create-app.js
+++ b/src/create-app.js
@@ -1,0 +1,103 @@
+const http = require('node:http');
+const { RETENTION_DAYS } = require('./audit-store');
+
+function createApp(options) {
+  return http.createServer(createHandler(options));
+}
+
+function createHandler(options) {
+  if (!options || !options.store) {
+    throw new Error('createHandler requires a store');
+  }
+
+  const { store } = options;
+
+  return async (request, response) => {
+    try {
+      const url = new URL(request.url, 'http://localhost');
+      const incidentMatch = url.pathname.match(/^\/api\/incidents\/([^/]+)\/actions$/);
+      const policyMatch = url.pathname.match(/^\/api\/policies\/([^/]+)\/changes$/);
+
+      if (request.method === 'POST' && incidentMatch) {
+        const body = await readJsonBody(request);
+        const record = store.recordIncidentAction({
+          incidentId: decodeURIComponent(incidentMatch[1]),
+          actionType: body.actionType,
+          actor: body.actor,
+          note: body.note,
+          occurredAt: body.occurredAt
+        });
+
+        return writeJson(response, 201, record);
+      }
+
+      if (request.method === 'GET' && incidentMatch) {
+        return writeJson(response, 200, {
+          retentionDays: RETENTION_DAYS,
+          items: store.listIncidentActions(decodeURIComponent(incidentMatch[1]))
+        });
+      }
+
+      if (request.method === 'POST' && policyMatch) {
+        const body = await readJsonBody(request);
+        const record = store.recordPolicyChange({
+          policyId: decodeURIComponent(policyMatch[1]),
+          changeType: body.changeType,
+          actor: body.actor,
+          summary: body.summary,
+          before: body.before,
+          after: body.after,
+          occurredAt: body.occurredAt
+        });
+
+        return writeJson(response, 201, record);
+      }
+
+      if (request.method === 'GET' && policyMatch) {
+        return writeJson(response, 200, {
+          retentionDays: RETENTION_DAYS,
+          items: store.listPolicyChanges(decodeURIComponent(policyMatch[1]))
+        });
+      }
+
+      return writeJson(response, 404, { error: 'Not found' });
+    } catch (error) {
+      const statusCode = error.statusCode ?? 400;
+      return writeJson(response, statusCode, { error: error.message });
+    }
+  };
+}
+
+async function readJsonBody(request) {
+  const chunks = [];
+
+  for await (const chunk of request) {
+    chunks.push(chunk);
+  }
+
+  if (chunks.length === 0) {
+    return {};
+  }
+
+  const bodyText = Buffer.concat(chunks).toString('utf8');
+
+  try {
+    return JSON.parse(bodyText);
+  } catch {
+    const error = new Error('Request body must be valid JSON');
+    error.statusCode = 400;
+    throw error;
+  }
+}
+
+function writeJson(response, statusCode, payload) {
+  response.writeHead(statusCode, {
+    'content-type': 'application/json; charset=utf-8'
+  });
+  response.end(JSON.stringify(payload));
+}
+
+module.exports = {
+  createApp,
+  createHandler
+};

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,21 @@
+const { AuditStore } = require('./audit-store');
+const { createApp } = require('./create-app');
+
+const port = Number(process.env.PORT ?? 3000);
+const dbPath = process.env.DB_PATH ?? ':memory:';
+
+const store = new AuditStore({ dbPath });
+const server = createApp({ store });
+
+server.listen(port, () => {
+  process.stdout.write(`site-monitor audit API listening on :${port}\n`);
+});
+
+function shutdown() {
+  server.close(() => {
+    store.close();
+  });
+}
+
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);

--- a/test/auditability.test.js
+++ b/test/auditability.test.js
@@ -1,0 +1,137 @@
+const assert = require('node:assert/strict');
+const { Readable } = require('node:stream');
+const test = require('node:test');
+const { AuditStore, RETENTION_DAYS } = require('../src/audit-store');
+const { createHandler } = require('../src/create-app');
+
+test('purgeExpiredRecords preserves the 90-day boundary for audit data', () => {
+  const store = new AuditStore();
+
+  try {
+    store.recordIncidentAction({
+      incidentId: 'inc-204',
+      actionType: 'acknowledge',
+      actor: 'oncall@example.com',
+      note: 'older than retention',
+      occurredAt: '2026-01-05T23:59:59.000Z'
+    });
+    store.recordIncidentAction({
+      incidentId: 'inc-204',
+      actionType: 'mute',
+      actor: 'oncall@example.com',
+      note: 'exactly at retention boundary',
+      occurredAt: '2026-01-06T00:00:00.000Z'
+    });
+    store.recordPolicyChange({
+      policyId: 'policy-primary',
+      changeType: 'threshold-updated',
+      actor: 'reliability@example.com',
+      summary: 'older than retention',
+      before: { failureThreshold: 2 },
+      after: { failureThreshold: 3 },
+      occurredAt: '2026-01-04T23:59:59.000Z'
+    });
+    store.recordPolicyChange({
+      policyId: 'policy-primary',
+      changeType: 'channels-updated',
+      actor: 'reliability@example.com',
+      summary: 'inside retention',
+      before: { channels: ['email'] },
+      after: { channels: ['email', 'pager'] },
+      occurredAt: '2026-01-06T00:00:00.000Z'
+    });
+
+    const result = store.purgeExpiredRecords({
+      referenceTime: '2026-04-06T00:00:00.000Z'
+    });
+
+    assert.deepEqual(result, {
+      referenceTime: '2026-04-06T00:00:00.000Z',
+      retentionDays: RETENTION_DAYS,
+      incidentActionsDeleted: 1,
+      policyChangesDeleted: 1
+    });
+
+    assert.deepEqual(store.listIncidentActions('inc-204').map((item) => item.note), [
+      'exactly at retention boundary'
+    ]);
+    assert.deepEqual(store.listPolicyChanges('policy-primary').map((item) => item.summary), [
+      'inside retention'
+    ]);
+  } finally {
+    store.close();
+  }
+});
+
+test('API exposes retained incident actions and policy changes', async () => {
+  const store = new AuditStore();
+  const handler = createHandler({ store });
+
+  try {
+    let response = await invokeJson(handler, 'POST', '/api/incidents/inc-204/actions', {
+      actionType: 'acknowledge',
+      actor: 'oncall@example.com',
+      note: 'Investigating payment failures'
+    });
+
+    assert.equal(response.statusCode, 201);
+    assert.equal(response.body.actionType, 'acknowledge');
+    assert.equal(response.body.actor, 'oncall@example.com');
+
+    response = await invokeJson(handler, 'GET', '/api/incidents/inc-204/actions');
+    assert.equal(response.statusCode, 200);
+    assert.equal(response.body.retentionDays, RETENTION_DAYS);
+    assert.equal(response.body.items.length, 1);
+    assert.equal(response.body.items[0].note, 'Investigating payment failures');
+
+    response = await invokeJson(handler, 'POST', '/api/policies/policy-primary/changes', {
+      changeType: 'channels-updated',
+      actor: 'reliability@example.com',
+      summary: 'Added pager escalation',
+      before: { channels: ['email'] },
+      after: { channels: ['email', 'pager'] }
+    });
+
+    assert.equal(response.statusCode, 201);
+    assert.equal(response.body.summary, 'Added pager escalation');
+    assert.deepEqual(response.body.after, { channels: ['email', 'pager'] });
+
+    response = await invokeJson(handler, 'GET', '/api/policies/policy-primary/changes');
+    assert.equal(response.statusCode, 200);
+    assert.equal(response.body.retentionDays, RETENTION_DAYS);
+    assert.equal(response.body.items.length, 1);
+    assert.deepEqual(response.body.items[0].before, { channels: ['email'] });
+  } finally {
+    store.close();
+  }
+});
+
+async function invokeJson(handler, method, path, payload) {
+  const bodyText = payload === undefined ? '' : JSON.stringify(payload);
+  const request = Readable.from(bodyText ? [Buffer.from(bodyText)] : []);
+  request.method = method;
+  request.url = path;
+
+  const response = createMockResponse();
+  await handler(request, response);
+
+  return {
+    statusCode: response.statusCode,
+    body: JSON.parse(response.bodyText)
+  };
+}
+
+function createMockResponse() {
+  return {
+    statusCode: 200,
+    headers: {},
+    bodyText: '',
+    writeHead(statusCode, headers) {
+      this.statusCode = statusCode;
+      this.headers = headers;
+    },
+    end(bodyText) {
+      this.bodyText = bodyText;
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- add a SQLite-backed audit store for incident actions and policy changes
- expose minimal API handlers for recording and listing retained audit records
- add retention and API verification tests, and link NFR-006 in the traceability matrix

## What This PR Advances
This PR delivers the smallest reviewable implementation slice for issue #11 ([NFR-006] Auditability).

## Reviewer Verification
- run npm test
- inspect src/audit-store.js to confirm audit records at exactly 90 days are retained while older rows are purged
- inspect src/create-app.js and test/auditability.test.js to confirm incident actions and policy changes are writable and readable through the API contract

Closes none. Advances #11.