### PR TITLE
Implement REQ-003 dashboard

### DIFF
--- a/docs/qa/traceability-matrix.md
+++ b/docs/qa/traceability-matrix.md
@@ -9,7 +9,7 @@
 |----|-------------|-------|----|----------------|------------------|--------|
 | REQ-001 | As a reliability engineer, I want to create and manage monitors so that important sites and endpoints are checked automatically. | [#1](https://github.com/IDNTEQ/site-monitor/issues/1) |  | `` |  | Pending |
 | REQ-002 | As a reliability engineer, I want to configure alert policies and maintenance windows so that responders are notified only when failures are actionable. | [#2](https://github.com/IDNTEQ/site-monitor/issues/2) |  | `` |  | Pending |
-| REQ-003 | As an on-call responder, I want a dashboard of current monitor status and open incidents so that I can see what needs attention immediately. | [#3](https://github.com/IDNTEQ/site-monitor/issues/3) |  | `` |  | Pending |
+| REQ-003 | As an on-call responder, I want a dashboard of current monitor status and open incidents so that I can see what needs attention immediately. | [#3](https://github.com/IDNTEQ/site-monitor/issues/3) |  | `test/api.test.js:70`, `test/page-routes.test.js:55` |  | Needs Review |
 | REQ-004 | As an on-call responder, I want an incident timeline with failure evidence so that I can triage without searching raw logs elsewhere. | [#4](https://github.com/IDNTEQ/site-monitor/issues/4) |  | `` |  | Pending |
 | REQ-005 | As an on-call responder, I want to acknowledge, mute, and resolve incidents so that the team has clear operational ownership during an outage. | [#5](https://github.com/IDNTEQ/site-monitor/issues/5) |  | `` |  | Pending |
 | NFR-001 | Detection latency | [#6](https://github.com/IDNTEQ/site-monitor/issues/6) |  | `` |  | Pending |

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "site-monitor",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node src/index.js",
+    "test": "node --test"
+  }
+}

--- a/src/http/app.js
+++ b/src/http/app.js
@@ -1,0 +1,206 @@
+import http from "node:http";
+
+import { InMemoryMonitorRepository } from "../repositories/in-memory-monitor-repository.js";
+import { createDashboardService, IncidentNotFoundError } from "../services/dashboard-service.js";
+import {
+  renderDashboardPage,
+  renderHtmlErrorPage,
+  renderIncidentSummaryPage,
+} from "./pages.js";
+
+function writeResponse(response, statusCode, body, contentType, headers = {}) {
+  response.writeHead(statusCode, {
+    "content-type": contentType,
+    ...headers,
+  });
+  response.end(body);
+}
+
+function createJsonResponse(response, statusCode, payload) {
+  writeResponse(
+    response,
+    statusCode,
+    JSON.stringify(payload),
+    "application/json; charset=utf-8",
+  );
+}
+
+function createHtmlResponse(response, statusCode, body, headers) {
+  writeResponse(response, statusCode, body, "text/html; charset=utf-8", headers);
+}
+
+function htmlResult(statusCode, body, headers) {
+  return {
+    statusCode,
+    contentType: "text/html; charset=utf-8",
+    body,
+    headers,
+  };
+}
+
+export async function handleApiRequest({
+  service,
+  method,
+  pathname,
+  searchParams = new URLSearchParams(),
+}) {
+  if (method === "GET" && pathname === "/api/dashboard") {
+    const dashboard = await service.getDashboard({
+      asOf: searchParams.get("asOf") ?? undefined,
+      datasetDays: searchParams.get("datasetDays") ?? undefined,
+      monitorLimit: searchParams.get("monitorLimit") ?? undefined,
+      incidentLimit: searchParams.get("incidentLimit") ?? undefined,
+      environment: searchParams.get("environment") ?? undefined,
+      status: searchParams.get("status") ?? undefined,
+      tag: searchParams.get("tag") ?? undefined,
+      recentIncidentState: searchParams.get("recentIncidentState") ?? undefined,
+    });
+
+    return {
+      statusCode: 200,
+      payload: { dashboard },
+    };
+  }
+
+  return {
+    statusCode: 404,
+    payload: {
+      error: "Route not found.",
+    },
+  };
+}
+
+export async function handlePageRequest({
+  service,
+  method,
+  pathname,
+  searchParams = new URLSearchParams(),
+}) {
+  if (method === "GET" && pathname === "/") {
+    return htmlResult(303, "", {
+      location: "/dashboard",
+    });
+  }
+
+  if (method === "GET" && pathname === "/dashboard") {
+    const filters = {
+      asOf: searchParams.get("asOf") ?? undefined,
+      environment: searchParams.get("environment") ?? undefined,
+      status: searchParams.get("status") ?? undefined,
+      tag: searchParams.get("tag") ?? undefined,
+      recentIncidentState: searchParams.get("recentIncidentState") ?? undefined,
+    };
+    const dashboard = await service.getDashboard(filters);
+    return htmlResult(200, renderDashboardPage(dashboard, filters));
+  }
+
+  const incidentRouteMatch = pathname.match(/^\/incidents\/([^/]+)$/);
+  if (method === "GET" && incidentRouteMatch) {
+    const incident = await service.getIncidentSummary(incidentRouteMatch[1]);
+    return htmlResult(200, renderIncidentSummaryPage(incident));
+  }
+
+  return htmlResult(404, renderHtmlErrorPage("Page not found", "Route not found."));
+}
+
+function createDefaultService() {
+  return createDashboardService({
+    repository: new InMemoryMonitorRepository({
+      monitors: [
+        {
+          id: "mon-homepage",
+          name: "Homepage",
+          environment: "production",
+          url: "https://example.com",
+          status: "active",
+          healthState: "healthy",
+          recentIncidentState: "resolved",
+          tags: ["web"],
+          lastCheckAt: "2026-04-06T12:04:00.000Z",
+          responseTimeMs: 128,
+          createdAt: "2026-04-01T09:00:00.000Z",
+          updatedAt: "2026-04-06T12:04:00.000Z",
+          currentIncident: null,
+        },
+        {
+          id: "mon-billing",
+          name: "Billing",
+          environment: "production",
+          url: "https://example.com/billing",
+          status: "active",
+          healthState: "degraded",
+          recentIncidentState: "open",
+          tags: ["payments"],
+          lastCheckAt: "2026-04-06T12:03:00.000Z",
+          responseTimeMs: 0,
+          createdAt: "2026-04-01T09:00:00.000Z",
+          updatedAt: "2026-04-06T12:03:00.000Z",
+          currentIncident: {
+            id: "INC-204",
+            state: "open",
+            severity: "critical",
+            openedAt: "2026-04-06T11:55:00.000Z",
+          },
+        },
+        {
+          id: "mon-search",
+          name: "Search",
+          environment: "staging",
+          url: "https://staging.example.com/search",
+          status: "paused",
+          healthState: "healthy",
+          recentIncidentState: "none",
+          tags: ["search"],
+          lastCheckAt: "2026-04-06T11:00:00.000Z",
+          responseTimeMs: 142,
+          createdAt: "2026-04-01T09:00:00.000Z",
+          updatedAt: "2026-04-06T11:00:00.000Z",
+          currentIncident: null,
+        },
+      ],
+    }),
+    clock: () => new Date("2026-04-06T12:05:00.000Z"),
+  });
+}
+
+export function createApp({ service = createDefaultService() } = {}) {
+  return http.createServer(async (request, response) => {
+    const url = new URL(request.url, "http://127.0.0.1");
+
+    try {
+      if (url.pathname.startsWith("/api")) {
+        const result = await handleApiRequest({
+          service,
+          method: request.method,
+          pathname: url.pathname,
+          searchParams: url.searchParams,
+        });
+        createJsonResponse(response, result.statusCode, result.payload);
+        return;
+      }
+
+      const result = await handlePageRequest({
+        service,
+        method: request.method,
+        pathname: url.pathname,
+        searchParams: url.searchParams,
+      });
+      createHtmlResponse(response, result.statusCode, result.body, result.headers);
+    } catch (error) {
+      if (error instanceof IncidentNotFoundError) {
+        createHtmlResponse(
+          response,
+          404,
+          renderHtmlErrorPage("Incident not found", error.message),
+        );
+        return;
+      }
+
+      createHtmlResponse(
+        response,
+        500,
+        renderHtmlErrorPage("Unexpected error", "The dashboard request failed."),
+      );
+    }
+  });
+}

--- a/src/http/pages.js
+++ b/src/http/pages.js
@@ -1,0 +1,470 @@
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function humanizeLabel(value) {
+  return String(value)
+    .split(/[_-]/)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+function renderPage(title, currentPath, content) {
+  const dashboardCurrent = currentPath === "/dashboard" ? ' aria-current="page"' : "";
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>${escapeHtml(title)} | site-monitor</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --ink: #16202a;
+        --muted: #536272;
+        --surface: #eff4f8;
+        --card: #ffffff;
+        --line: #cfdae5;
+        --accent: #1558a6;
+        --alert: #a53030;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        font-family: Georgia, "Times New Roman", serif;
+        color: var(--ink);
+        background:
+          radial-gradient(circle at top left, #f7fbff 0%, transparent 28%),
+          linear-gradient(180deg, #e8eef5 0%, #f6f8fb 100%);
+      }
+      a {
+        color: var(--accent);
+      }
+      .skip-link {
+        position: absolute;
+        left: 1rem;
+        top: -3rem;
+        padding: 0.75rem 1rem;
+        background: #ffffff;
+        border: 2px solid var(--accent);
+      }
+      .skip-link:focus {
+        top: 1rem;
+      }
+      header {
+        background: #132030;
+        color: #ffffff;
+        padding: 1rem 1.25rem;
+      }
+      nav {
+        display: flex;
+        gap: 1rem;
+        flex-wrap: wrap;
+        align-items: center;
+      }
+      nav a {
+        color: inherit;
+        text-decoration: none;
+      }
+      nav a[aria-current="page"] {
+        text-decoration: underline;
+        text-underline-offset: 0.2rem;
+      }
+      main {
+        max-width: 1120px;
+        margin: 0 auto;
+        padding: 1.5rem 1rem 3rem;
+      }
+      section, form, article {
+        background: var(--card);
+        border: 1px solid var(--line);
+        border-radius: 0.85rem;
+        padding: 1rem;
+        margin-bottom: 1rem;
+        box-shadow: 0 10px 30px rgba(19, 32, 48, 0.05);
+      }
+      h1, h2, h3, p {
+        margin-top: 0;
+      }
+      .grid {
+        display: grid;
+        gap: 1rem;
+      }
+      .grid.cols-2 {
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      }
+      .grid.cols-4 {
+        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+      }
+      .summary-card {
+        background: linear-gradient(180deg, #ffffff 0%, #f7f9fc 100%);
+      }
+      .summary-count {
+        font-size: 1.95rem;
+        font-weight: 700;
+        margin-bottom: 0;
+      }
+      .status-label {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        font-weight: 700;
+      }
+      .muted {
+        color: var(--muted);
+      }
+      label {
+        display: block;
+        font-weight: 700;
+        margin-bottom: 0.3rem;
+      }
+      input, select {
+        width: 100%;
+        font: inherit;
+        padding: 0.55rem 0.7rem;
+        border: 1px solid #8ea0b3;
+        border-radius: 0.5rem;
+      }
+      button {
+        font: inherit;
+        padding: 0.65rem 0.95rem;
+        border: 1px solid #274d73;
+        border-radius: 0.5rem;
+        background: #173a5e;
+        color: #ffffff;
+        cursor: pointer;
+      }
+      .table-wrap {
+        overflow-x: auto;
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+      }
+      th, td {
+        text-align: left;
+        padding: 0.7rem 0.5rem;
+        border-bottom: 1px solid var(--line);
+        vertical-align: top;
+      }
+      .list-reset {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+      .incident-chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        padding: 0.2rem 0.6rem;
+        border-radius: 999px;
+        font-size: 0.92rem;
+        font-weight: 700;
+        text-decoration: none;
+      }
+      .incident-chip-open {
+        background: #ffe4de;
+        color: #7a1f1f;
+      }
+      .incident-chip-muted {
+        background: #edf3f8;
+        color: #40515f;
+      }
+      .incident-preview + .incident-preview {
+        margin-top: 0.85rem;
+        padding-top: 0.85rem;
+        border-top: 1px solid var(--line);
+      }
+      .table-empty {
+        padding: 1rem 0.5rem;
+      }
+      .error-panel {
+        border-color: #c66a6a;
+        background: #fff4f4;
+      }
+      dl {
+        display: grid;
+        grid-template-columns: minmax(150px, 220px) 1fr;
+        gap: 0.5rem 1rem;
+        margin: 0;
+      }
+      dt {
+        font-weight: 700;
+      }
+      dd {
+        margin: 0;
+      }
+      @media (max-width: 700px) {
+        main {
+          padding-inline: 0.75rem;
+        }
+        section, form, article {
+          padding: 0.85rem;
+        }
+        dl {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <a class="skip-link" href="#main-content">Skip to content</a>
+    <header>
+      <nav aria-label="Primary">
+        <strong>site-monitor</strong>
+        <a href="/dashboard"${dashboardCurrent}>Dashboard</a>
+      </nav>
+    </header>
+    <main id="main-content">${content}</main>
+  </body>
+</html>`;
+}
+
+function renderStatusLabel(label, icon) {
+  return `<span class="status-label"><span aria-hidden="true">${escapeHtml(icon)}</span> ${escapeHtml(
+    humanizeLabel(label),
+  )}</span>`;
+}
+
+function renderSelectOptions(options, selectedValue) {
+  return options
+    .map((option) => {
+      const selected = option.value === selectedValue ? ' selected="selected"' : "";
+      return `<option value="${escapeHtml(option.value)}"${selected}>${escapeHtml(option.label)}</option>`;
+    })
+    .join("");
+}
+
+function renderRecentIncidentCell(monitor) {
+  if (monitor.incidentId) {
+    return `<a class="incident-chip incident-chip-open" href="/incidents/${escapeHtml(
+      monitor.incidentId,
+    )}">! Open ${escapeHtml(monitor.incidentId)}</a>`;
+  }
+
+  const label =
+    monitor.recentIncidentState === "resolved"
+      ? "Resolved recently"
+      : monitor.recentIncidentState === "acknowledged"
+        ? "Acknowledged recently"
+        : "No recent incident";
+
+  return `<span class="incident-chip incident-chip-muted">${escapeHtml(label)}</span>`;
+}
+
+function renderIncidentAge(openedAt, asOf) {
+  if (!openedAt) {
+    return "Unknown age";
+  }
+
+  const ageMs = Date.parse(asOf) - Date.parse(openedAt);
+  if (Number.isNaN(ageMs) || ageMs < 0) {
+    return "Unknown age";
+  }
+
+  const ageMinutes = Math.floor(ageMs / (60 * 1000));
+  if (ageMinutes < 1) {
+    return "Opened less than a minute ago";
+  }
+
+  if (ageMinutes < 60) {
+    return `Opened ${ageMinutes} minute${ageMinutes === 1 ? "" : "s"} ago`;
+  }
+
+  const ageHours = Math.floor(ageMinutes / 60);
+  return `Opened ${ageHours} hour${ageHours === 1 ? "" : "s"} ago`;
+}
+
+function renderKeyValueRows(entries) {
+  return `<dl>${entries
+    .map(
+      ([key, value]) =>
+        `<dt>${escapeHtml(key)}</dt><dd>${value === null ? "None" : escapeHtml(value)}</dd>`,
+    )
+    .join("")}</dl>`;
+}
+
+export function renderDashboardPage(dashboard, filters = {}) {
+  const summaryCards = [
+    ["Healthy", dashboard.summary.healthy, "o"],
+    ["Degraded", dashboard.summary.degraded, "~"],
+    ["Incident monitors", dashboard.summary.incident, "!"],
+    ["Paused", dashboard.summary.paused, "="],
+  ];
+  const statusOptions = [
+    { value: "", label: "All statuses" },
+    { value: "healthy", label: "Healthy" },
+    { value: "degraded", label: "Degraded" },
+    { value: "incident", label: "Incident" },
+    { value: "paused", label: "Paused" },
+  ];
+  const recentIncidentOptions = [
+    { value: "", label: "Any recent incident state" },
+    { value: "open", label: "Open" },
+    { value: "acknowledged", label: "Acknowledged" },
+    { value: "resolved", label: "Resolved" },
+    { value: "none", label: "None" },
+  ];
+
+  return renderPage(
+    "Dashboard",
+    "/dashboard",
+    `<h1>Dashboard</h1>
+    <p class="muted">Showing the last ${escapeHtml(dashboard.dataset.days)} days from ${escapeHtml(
+      dashboard.dataset.startedAt,
+    )} to ${escapeHtml(dashboard.dataset.asOf)}.</p>
+    <section aria-labelledby="summary-title">
+      <h2 id="summary-title">Current health summary</h2>
+      <div class="grid cols-4">
+        ${summaryCards
+          .map(
+            ([label, count, icon]) => `<article class="summary-card">
+              <div>${renderStatusLabel(label, icon)}</div>
+              <p class="summary-count"${label === "Incident monitors" ? ' aria-live="polite"' : ""}>${escapeHtml(
+                count,
+              )}</p>
+            </article>`,
+          )
+          .join("")}
+      </div>
+    </section>
+    <form action="/dashboard" method="get" aria-labelledby="filters-title">
+      <h2 id="filters-title">Filters</h2>
+      <div class="grid cols-2">
+        <div>
+          <label for="environment-filter">Environment</label>
+          <input id="environment-filter" name="environment" value="${escapeHtml(
+            filters.environment ?? "",
+          )}" />
+        </div>
+        <div>
+          <label for="status-filter">Status</label>
+          <select id="status-filter" name="status">
+            ${renderSelectOptions(statusOptions, filters.status ?? "")}
+          </select>
+        </div>
+        <div>
+          <label for="tag-filter">Tag</label>
+          <input id="tag-filter" name="tag" value="${escapeHtml(filters.tag ?? "")}" />
+        </div>
+        <div>
+          <label for="recent-incident-state-filter">Recent incident state</label>
+          <select id="recent-incident-state-filter" name="recentIncidentState">
+            ${renderSelectOptions(recentIncidentOptions, filters.recentIncidentState ?? "")}
+          </select>
+        </div>
+      </div>
+      <input type="hidden" name="asOf" value="${escapeHtml(dashboard.dataset.asOf)}" />
+      <button type="submit">Apply filters</button>
+    </form>
+    <div class="grid cols-2">
+      <section aria-labelledby="monitor-table-title">
+        <h2 id="monitor-table-title">Monitor table</h2>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th scope="col">Monitor</th>
+                <th scope="col">Environment</th>
+                <th scope="col">Status</th>
+                <th scope="col">Recent incident</th>
+                <th scope="col">Last check</th>
+                <th scope="col">Latency</th>
+              </tr>
+            </thead>
+            <tbody>
+              ${
+                dashboard.monitors.length > 0
+                  ? dashboard.monitors
+                      .map(
+                        (monitor) => `<tr>
+                          <td>${escapeHtml(monitor.name)}</td>
+                          <td>${escapeHtml(monitor.environment)}</td>
+                          <td>${renderStatusLabel(
+                            monitor.status,
+                            monitor.status === "incident"
+                              ? "!"
+                              : monitor.status === "degraded"
+                                ? "~"
+                                : monitor.status === "paused"
+                                  ? "="
+                                  : "o",
+                          )}</td>
+                          <td>${renderRecentIncidentCell(monitor)}</td>
+                          <td>${escapeHtml(monitor.lastCheckAt ?? "No checks yet")}</td>
+                          <td>${escapeHtml(monitor.responseTimeMs ?? "n/a")}</td>
+                        </tr>`,
+                      )
+                      .join("")
+                  : '<tr><td class="table-empty" colspan="6">No monitors matched the current dashboard filters.</td></tr>'
+              }
+            </tbody>
+          </table>
+        </div>
+      </section>
+      <section aria-labelledby="open-incidents-title">
+        <h2 id="open-incidents-title">Open incidents</h2>
+        <ul class="list-reset">
+          ${
+            dashboard.openIncidents.length > 0
+              ? dashboard.openIncidents
+                  .map(
+                    (incident) => `<li class="incident-preview">
+                      <a href="/incidents/${escapeHtml(incident.id)}">${escapeHtml(incident.id)}</a>
+                      <div>${escapeHtml(incident.monitorName)}</div>
+                      <div>${renderStatusLabel(incident.severity, "!")}</div>
+                      <p class="muted">${escapeHtml(
+                        renderIncidentAge(incident.openedAt, dashboard.dataset.asOf),
+                      )}</p>
+                    </li>`,
+                  )
+                  .join("")
+              : '<li class="muted">No open incidents right now.</li>'
+          }
+        </ul>
+      </section>
+    </div>`,
+  );
+}
+
+export function renderIncidentSummaryPage(incident) {
+  return renderPage(
+    "Incident Summary",
+    "",
+    `<p><a href="/dashboard">Back to dashboard</a></p>
+    <h1>Incident Summary</h1>
+    <section aria-labelledby="incident-summary-title">
+      <h2 id="incident-summary-title">${escapeHtml(incident.id)}</h2>
+      ${renderKeyValueRows([
+        ["Monitor", incident.monitor.name],
+        ["Environment", incident.monitor.environment],
+        ["State", incident.state],
+        ["Severity", incident.severity],
+        ["Opened at", incident.openedAt ?? "Unknown"],
+        ["Acknowledged at", incident.acknowledgedAt ?? "Not acknowledged"],
+        ["Resolved at", incident.resolvedAt ?? "Not resolved"],
+      ])}
+    </section>
+    <section>
+      <h2>Responder note</h2>
+      <p class="muted">This route exists so dashboard incident links land on an operator-facing page while deeper timeline and action workflows are delivered separately.</p>
+    </section>`,
+  );
+}
+
+export function renderHtmlErrorPage(title, message) {
+  return renderPage(
+    title,
+    "",
+    `<section class="error-panel" role="alert">
+      <h1>${escapeHtml(title)}</h1>
+      <p>${escapeHtml(message)}</p>
+    </section>`,
+  );
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,8 @@
+import { createApp } from "./http/app.js";
+
+const port = Number.parseInt(process.env.PORT ?? "3000", 10);
+const app = createApp();
+
+app.listen(port, () => {
+  process.stdout.write(`site-monitor listening on http://127.0.0.1:${port}\n`);
+});

--- a/src/repositories/in-memory-monitor-repository.js
+++ b/src/repositories/in-memory-monitor-repository.js
@@ -1,0 +1,35 @@
+export class InMemoryMonitorRepository {
+  constructor({ monitors = [] } = {}) {
+    this.monitors = new Map(
+      monitors.map((monitor) => [monitor.id, structuredClone(monitor)]),
+    );
+  }
+
+  async listMonitors() {
+    return [...this.monitors.values()].map((monitor) => structuredClone(monitor));
+  }
+
+  async findIncidentById(incidentId) {
+    for (const monitor of this.monitors.values()) {
+      const currentIncident = monitor.currentIncident;
+      if (currentIncident?.id === incidentId) {
+        return structuredClone({
+          id: currentIncident.id,
+          state: currentIncident.state,
+          severity: currentIncident.severity ?? "unknown",
+          openedAt: currentIncident.openedAt ?? null,
+          acknowledgedAt: currentIncident.acknowledgedAt ?? null,
+          resolvedAt: currentIncident.resolvedAt ?? null,
+          monitor: {
+            id: monitor.id,
+            name: monitor.name,
+            environment: monitor.environment,
+            url: monitor.url,
+          },
+        });
+      }
+    }
+
+    return null;
+  }
+}

--- a/src/services/dashboard-service.js
+++ b/src/services/dashboard-service.js
@@ -1,0 +1,210 @@
+export class IncidentNotFoundError extends Error {
+  constructor(incidentId) {
+    super(`Incident ${incidentId} was not found.`);
+    this.name = "IncidentNotFoundError";
+  }
+}
+
+function normalizeTimestamp(value, fieldName) {
+  const timestamp = value instanceof Date ? value.toISOString() : value;
+  const parsed = new Date(timestamp);
+
+  if (Number.isNaN(parsed.getTime())) {
+    throw new TypeError(`${fieldName} must be a valid ISO timestamp.`);
+  }
+
+  return parsed.toISOString();
+}
+
+function normalizeBoundedInteger(value, { defaultValue, minimum, maximum }) {
+  if (value === undefined || value === null || value === "") {
+    return defaultValue;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  if (Number.isNaN(parsed)) {
+    return defaultValue;
+  }
+
+  return Math.min(maximum, Math.max(minimum, parsed));
+}
+
+function deriveDashboardStatus(monitor) {
+  if (monitor.status === "paused") {
+    return "paused";
+  }
+
+  if (monitor.currentIncident?.state === "open") {
+    return "incident";
+  }
+
+  if (monitor.healthState === "degraded") {
+    return "degraded";
+  }
+
+  return "healthy";
+}
+
+function deriveRecentIncidentState(monitor) {
+  if (typeof monitor.recentIncidentState === "string") {
+    return monitor.recentIncidentState;
+  }
+
+  if (monitor.currentIncident?.state === "open") {
+    return "open";
+  }
+
+  return "none";
+}
+
+function compareDescendingTimestamps(left, right, leftTimestamp, rightTimestamp) {
+  if (leftTimestamp && rightTimestamp && leftTimestamp !== rightTimestamp) {
+    return rightTimestamp.localeCompare(leftTimestamp);
+  }
+
+  if (rightTimestamp) {
+    return 1;
+  }
+
+  if (leftTimestamp) {
+    return -1;
+  }
+
+  return left.name.localeCompare(right.name);
+}
+
+export function createDashboardService({
+  repository,
+  clock = () => new Date(),
+}) {
+  async function getDashboard(filters = {}) {
+    const asOf = normalizeTimestamp(filters.asOf ?? clock(), "asOf");
+    const datasetDays = normalizeBoundedInteger(filters.datasetDays, {
+      defaultValue: 30,
+      minimum: 1,
+      maximum: 30,
+    });
+    const monitorLimit = normalizeBoundedInteger(filters.monitorLimit, {
+      defaultValue: 50,
+      minimum: 1,
+      maximum: 100,
+    });
+    const incidentLimit = normalizeBoundedInteger(filters.incidentLimit, {
+      defaultValue: 10,
+      minimum: 1,
+      maximum: 25,
+    });
+    const startedAt = new Date(
+      Date.parse(asOf) - datasetDays * 24 * 60 * 60 * 1000,
+    ).toISOString();
+    const monitors = (await repository.listMonitors())
+      .filter((monitor) => monitor.status !== "archived")
+      .filter((monitor) => {
+        const activityAt =
+          monitor.lastCheckAt ??
+          monitor.currentIncident?.openedAt ??
+          monitor.updatedAt ??
+          monitor.createdAt ??
+          null;
+
+        if (!activityAt) {
+          return true;
+        }
+
+        return activityAt >= startedAt && activityAt <= asOf;
+      });
+
+    const rows = monitors.map((monitor) => ({
+      id: monitor.id,
+      name: monitor.name,
+      environment: monitor.environment,
+      tags: monitor.tags ?? [],
+      status: deriveDashboardStatus(monitor),
+      recentIncidentState: deriveRecentIncidentState(monitor),
+      incidentId: monitor.currentIncident?.id ?? null,
+      lastCheckAt: monitor.lastCheckAt ?? null,
+      responseTimeMs: monitor.responseTimeMs ?? null,
+    }));
+
+    const summary = {
+      healthy: rows.filter((monitor) => monitor.status === "healthy").length,
+      degraded: rows.filter((monitor) => monitor.status === "degraded").length,
+      paused: rows.filter((monitor) => monitor.status === "paused").length,
+      incident: rows.filter((monitor) => monitor.status === "incident").length,
+    };
+
+    const filteredMonitors = rows
+      .filter((monitor) => {
+        if (filters.environment && monitor.environment !== filters.environment) {
+          return false;
+        }
+
+        if (filters.status && monitor.status !== filters.status) {
+          return false;
+        }
+
+        if (filters.tag && !monitor.tags.includes(filters.tag)) {
+          return false;
+        }
+
+        if (
+          filters.recentIncidentState &&
+          monitor.recentIncidentState !== filters.recentIncidentState
+        ) {
+          return false;
+        }
+
+        return true;
+      })
+      .sort((left, right) =>
+        compareDescendingTimestamps(left, right, left.lastCheckAt, right.lastCheckAt),
+      );
+
+    const openIncidents = monitors
+      .filter((monitor) => monitor.currentIncident?.state === "open")
+      .map((monitor) => ({
+        id: monitor.currentIncident.id,
+        monitorId: monitor.id,
+        monitorName: monitor.name,
+        state: monitor.currentIncident.state,
+        severity: monitor.currentIncident.severity ?? "unknown",
+        openedAt: monitor.currentIncident.openedAt ?? null,
+        link: `/incidents/${monitor.currentIncident.id}`,
+      }))
+      .sort((left, right) =>
+        compareDescendingTimestamps(left, right, left.openedAt, right.openedAt),
+      );
+
+    return {
+      summary,
+      dataset: {
+        asOf,
+        startedAt,
+        days: datasetDays,
+        monitorLimit,
+        incidentLimit,
+        totalMonitorRows: filteredMonitors.length,
+        totalOpenIncidents: openIncidents.length,
+        truncatedMonitors: filteredMonitors.length > monitorLimit,
+        truncatedOpenIncidents: openIncidents.length > incidentLimit,
+      },
+      monitors: filteredMonitors.slice(0, monitorLimit),
+      openIncidents: openIncidents.slice(0, incidentLimit),
+    };
+  }
+
+  async function getIncidentSummary(incidentId) {
+    const incident = await repository.findIncidentById(incidentId);
+
+    if (!incident) {
+      throw new IncidentNotFoundError(incidentId);
+    }
+
+    return incident;
+  }
+
+  return {
+    getDashboard,
+    getIncidentSummary,
+  };
+}

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -1,0 +1,133 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { handleApiRequest } from "../src/http/app.js";
+import { InMemoryMonitorRepository } from "../src/repositories/in-memory-monitor-repository.js";
+import { createDashboardService } from "../src/services/dashboard-service.js";
+
+function createService() {
+  const repository = new InMemoryMonitorRepository({
+    monitors: [
+      {
+        id: "mon-homepage",
+        name: "Homepage",
+        environment: "production",
+        url: "https://example.com",
+        status: "active",
+        healthState: "healthy",
+        recentIncidentState: "resolved",
+        tags: ["web"],
+        lastCheckAt: "2026-04-06T12:04:00.000Z",
+        responseTimeMs: 120,
+        createdAt: "2026-04-01T09:00:00.000Z",
+        updatedAt: "2026-04-06T12:04:00.000Z",
+        currentIncident: null,
+      },
+      {
+        id: "mon-billing",
+        name: "Billing",
+        environment: "production",
+        url: "https://example.com/billing",
+        status: "active",
+        healthState: "degraded",
+        recentIncidentState: "open",
+        tags: ["payments"],
+        lastCheckAt: "2026-04-06T12:03:00.000Z",
+        responseTimeMs: 0,
+        createdAt: "2026-04-01T09:00:00.000Z",
+        updatedAt: "2026-04-06T12:03:00.000Z",
+        currentIncident: {
+          id: "INC-204",
+          state: "open",
+          severity: "critical",
+          openedAt: "2026-04-06T11:55:00.000Z",
+        },
+      },
+      {
+        id: "mon-search",
+        name: "Search",
+        environment: "staging",
+        url: "https://staging.example.com/search",
+        status: "paused",
+        healthState: "healthy",
+        recentIncidentState: "none",
+        tags: ["search"],
+        lastCheckAt: "2026-04-06T11:00:00.000Z",
+        responseTimeMs: 142,
+        createdAt: "2026-04-01T09:00:00.000Z",
+        updatedAt: "2026-04-06T11:00:00.000Z",
+        currentIncident: null,
+      },
+    ],
+  });
+
+  return createDashboardService({
+    repository,
+    clock: () => new Date("2026-04-06T12:05:00.000Z"),
+  });
+}
+
+test("GET /api/dashboard returns summary counts, filtered rows, and open incidents", async () => {
+  const result = await handleApiRequest({
+    service: createService(),
+    method: "GET",
+    pathname: "/api/dashboard",
+    searchParams: new URLSearchParams({
+      asOf: "2026-04-06T12:05:00.000Z",
+      environment: "production",
+      status: "healthy",
+      tag: "web",
+      recentIncidentState: "resolved",
+    }),
+  });
+
+  assert.equal(result.statusCode, 200);
+  assert.deepEqual(result.payload.dashboard.summary, {
+    healthy: 1,
+    degraded: 0,
+    paused: 1,
+    incident: 1,
+  });
+  assert.equal(result.payload.dashboard.monitors.length, 1);
+  assert.equal(result.payload.dashboard.monitors[0].id, "mon-homepage");
+  assert.deepEqual(result.payload.dashboard.openIncidents, [
+    {
+      id: "INC-204",
+      monitorId: "mon-billing",
+      monitorName: "Billing",
+      state: "open",
+      severity: "critical",
+      openedAt: "2026-04-06T11:55:00.000Z",
+      link: "/incidents/INC-204",
+    },
+  ]);
+});
+
+test("GET /api/dashboard applies dataset window and payload limits", async () => {
+  const result = await handleApiRequest({
+    service: createService(),
+    method: "GET",
+    pathname: "/api/dashboard",
+    searchParams: new URLSearchParams({
+      asOf: "2026-04-06T12:05:00.000Z",
+      datasetDays: "30",
+      monitorLimit: "1",
+      incidentLimit: "1",
+    }),
+  });
+
+  assert.equal(result.statusCode, 200);
+  assert.equal(result.payload.dashboard.monitors.length, 1);
+  assert.equal(result.payload.dashboard.openIncidents.length, 1);
+  assert.deepEqual(result.payload.dashboard.dataset, {
+    asOf: "2026-04-06T12:05:00.000Z",
+    startedAt: "2026-03-07T12:05:00.000Z",
+    days: 30,
+    monitorLimit: 1,
+    incidentLimit: 1,
+    totalMonitorRows: 3,
+    totalOpenIncidents: 1,
+    truncatedMonitors: true,
+    truncatedOpenIncidents: false,
+  });
+});

--- a/test/page-routes.test.js
+++ b/test/page-routes.test.js
@@ -1,0 +1,104 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { handlePageRequest } from "../src/http/app.js";
+import { InMemoryMonitorRepository } from "../src/repositories/in-memory-monitor-repository.js";
+import { createDashboardService } from "../src/services/dashboard-service.js";
+
+function createService() {
+  const repository = new InMemoryMonitorRepository({
+    monitors: [
+      {
+        id: "mon-homepage",
+        name: "Homepage",
+        environment: "production",
+        url: "https://example.com",
+        status: "active",
+        healthState: "healthy",
+        recentIncidentState: "resolved",
+        tags: ["web"],
+        lastCheckAt: "2026-04-06T12:04:00.000Z",
+        responseTimeMs: 120,
+        createdAt: "2026-04-01T09:00:00.000Z",
+        updatedAt: "2026-04-06T12:04:00.000Z",
+        currentIncident: null,
+      },
+      {
+        id: "mon-billing",
+        name: "Billing",
+        environment: "production",
+        url: "https://example.com/billing",
+        status: "active",
+        healthState: "degraded",
+        recentIncidentState: "open",
+        tags: ["payments"],
+        lastCheckAt: "2026-04-06T12:03:00.000Z",
+        responseTimeMs: 0,
+        createdAt: "2026-04-01T09:00:00.000Z",
+        updatedAt: "2026-04-06T12:03:00.000Z",
+        currentIncident: {
+          id: "INC-204",
+          state: "open",
+          severity: "critical",
+          openedAt: "2026-04-06T11:55:00.000Z",
+        },
+      },
+    ],
+  });
+
+  return createDashboardService({
+    repository,
+    clock: () => new Date("2026-04-06T12:05:00.000Z"),
+  });
+}
+
+test("GET /dashboard renders summary counts, filters, and direct incident links", async () => {
+  const result = await handlePageRequest({
+    service: createService(),
+    method: "GET",
+    pathname: "/dashboard",
+    searchParams: new URLSearchParams({
+      asOf: "2026-04-06T12:05:00.000Z",
+    }),
+  });
+
+  assert.equal(result.statusCode, 200);
+  assert.equal(result.contentType, "text/html; charset=utf-8");
+  assert.match(result.body, /<main id="main-content">/);
+  assert.match(result.body, /<label for="environment-filter">Environment<\/label>/);
+  assert.match(result.body, /<label for="recent-incident-state-filter">Recent incident state<\/label>/);
+  assert.match(result.body, /Incident monitors/);
+  assert.match(result.body, /aria-live="polite"/);
+  assert.match(result.body, /! Open INC-204/);
+  assert.match(result.body, /href="\/incidents\/INC-204"/);
+  assert.match(result.body, /Opened 10 minutes ago/);
+});
+
+test("GET /dashboard renders a clear empty state when filters remove all monitors", async () => {
+  const result = await handlePageRequest({
+    service: createService(),
+    method: "GET",
+    pathname: "/dashboard",
+    searchParams: new URLSearchParams({
+      asOf: "2026-04-06T12:05:00.000Z",
+      environment: "staging",
+    }),
+  });
+
+  assert.equal(result.statusCode, 200);
+  assert.match(result.body, /No monitors matched the current dashboard filters\./);
+});
+
+test("GET /incidents/:incidentId renders an operator-facing incident summary page", async () => {
+  const result = await handlePageRequest({
+    service: createService(),
+    method: "GET",
+    pathname: "/incidents/INC-204",
+  });
+
+  assert.equal(result.statusCode, 200);
+  assert.match(result.body, /<h1>Incident Summary<\/h1>/);
+  assert.match(result.body, /Billing/);
+  assert.match(result.body, /critical/);
+  assert.match(result.body, /Back to dashboard/);
+});


### PR DESCRIPTION
Summary:
- implement the initial dashboard API and server-rendered dashboard for REQ-003
- show current monitor status counts, filterable monitor rows, and open incident highlights with direct links
- add a lightweight incident summary landing page so dashboard incident links resolve during QA
- update the traceability matrix entry for REQ-003 with test references

Reviewer verification:
- run npm test
- open the dashboard route and confirm the summary cards show healthy, degraded, incident, and paused monitor counts
- confirm filters apply to environment, status, tag, and recent incident state
- confirm open incidents are highlighted in both the monitor table and the incident list, and links land on the incident summary route

Advances #3