### PR TITLE
[NFR-003] Ship a server-rendered dashboard budget slice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# site-monitor
+
+Minimal dashboard implementation for issue `#8 [NFR-003] Dashboard load time`.
+
+## Commands
+
+- `npm start` starts the local dashboard server on `http://127.0.0.1:3000`
+- `npm test` runs the fixture, filter, and payload-budget tests
+- `npm run perf:budget` measures initial HTML size and server-side render time
+- `npm exec --yes --package=puppeteer --package=lighthouse --package=chrome-launcher node scripts/lighthouse-profile.mjs` runs an optional Lighthouse pass with temporary browser tooling
+
+## Scope
+
+The current implementation is intentionally narrow:
+
+- primary dashboard content is server-rendered in the first document
+- the 30-day dataset slice is represented as precomputed monitor aggregates
+- filter interactions happen client-side without a full page reload
+- there are no external frontend dependencies or font/network requests on first paint

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "site-monitor-dashboard",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node server.mjs",
+    "test": "node --test",
+    "perf:budget": "node scripts/profile-dashboard.mjs",
+    "perf:lighthouse": "node scripts/lighthouse-profile.mjs"
+  }
+}

--- a/scripts/lighthouse-profile.mjs
+++ b/scripts/lighthouse-profile.mjs
@@ -1,0 +1,81 @@
+import http from "node:http";
+import process from "node:process";
+import lighthouse from "lighthouse";
+import { launch } from "chrome-launcher";
+import puppeteer from "puppeteer";
+import { renderDashboardPage } from "../src/dashboard-page.mjs";
+
+const port = 3344;
+
+const server = http.createServer((request, response) => {
+  if (!request.url || request.url === "/" || request.url.startsWith("/?")) {
+    response.writeHead(200, {
+      "content-type": "text/html; charset=utf-8",
+      "cache-control": "no-store"
+    });
+    response.end(renderDashboardPage());
+    return;
+  }
+
+  response.writeHead(404, { "content-type": "text/plain; charset=utf-8" });
+  response.end("Not found");
+});
+
+function pickAuditValue(lhr, id) {
+  const value = lhr.audits[id]?.numericValue;
+  return typeof value === "number" ? Number((value / 1000).toFixed(2)) : null;
+}
+
+await new Promise((resolve, reject) => {
+  server.listen(port, "127.0.0.1", (error) => {
+    if (error) {
+      reject(error);
+      return;
+    }
+    resolve();
+  });
+});
+
+const chrome = await launch({
+  chromePath: puppeteer.executablePath(),
+  chromeFlags: ["--headless=new", "--no-sandbox", "--disable-dev-shm-usage"]
+});
+
+try {
+  const result = await lighthouse(`http://127.0.0.1:${port}/`, {
+    port: chrome.port,
+    throttlingMethod: "simulate",
+    formFactor: "mobile",
+    screenEmulation: {
+      mobile: true,
+      width: 390,
+      height: 844,
+      deviceScaleFactor: 2,
+      disabled: false
+    },
+    throttling: {
+      rttMs: 300,
+      throughputKbps: 400,
+      cpuSlowdownMultiplier: 4,
+      requestLatencyMs: 300,
+      downloadThroughputKbps: 400,
+      uploadThroughputKbps: 400
+    },
+    onlyCategories: ["performance"]
+  });
+
+  const { lhr } = result;
+  const metrics = {
+    performanceScore: lhr.categories.performance.score,
+    firstContentfulPaintSeconds: pickAuditValue(lhr, "first-contentful-paint"),
+    largestContentfulPaintSeconds: pickAuditValue(lhr, "largest-contentful-paint"),
+    speedIndexSeconds: pickAuditValue(lhr, "speed-index"),
+    interactiveSeconds: pickAuditValue(lhr, "interactive"),
+    totalBlockingTimeSeconds: pickAuditValue(lhr, "total-blocking-time")
+  };
+
+  process.stdout.write(`${JSON.stringify(metrics, null, 2)}\n`);
+} finally {
+  await chrome.kill();
+  await new Promise((resolve) => server.close(resolve));
+}

--- a/scripts/profile-dashboard.mjs
+++ b/scripts/profile-dashboard.mjs
@@ -1,0 +1,18 @@
+import { performance } from "node:perf_hooks";
+import { renderDashboardPage } from "../src/dashboard-page.mjs";
+
+const startedAt = performance.now();
+const html = renderDashboardPage();
+const durationMs = performance.now() - startedAt;
+const bytes = Buffer.byteLength(html, "utf8");
+
+process.stdout.write(`Dashboard HTML bytes: ${bytes}\n`);
+process.stdout.write(`Dashboard render time: ${durationMs.toFixed(2)}ms\n`);
+
+if (bytes > 140000) {
+  throw new Error(`Dashboard HTML exceeded 140000 byte budget: ${bytes}`);
+}
+
+if (durationMs > 120) {
+  throw new Error(`Dashboard render exceeded 120ms local budget: ${durationMs.toFixed(2)}ms`);
+}

--- a/server.mjs
+++ b/server.mjs
@@ -1,0 +1,29 @@
+import http from "node:http";
+import { renderDashboardPage } from "./src/dashboard-page.mjs";
+
+const port = Number(process.env.PORT || 3000);
+
+const server = http.createServer((request, response) => {
+  if (!request.url || request.url === "/" || request.url.startsWith("/?")) {
+    const html = renderDashboardPage();
+    response.writeHead(200, {
+      "content-type": "text/html; charset=utf-8",
+      "cache-control": "no-store"
+    });
+    response.end(html);
+    return;
+  }
+
+  if (request.url === "/healthz") {
+    response.writeHead(200, { "content-type": "application/json; charset=utf-8" });
+    response.end(JSON.stringify({ ok: true }));
+    return;
+  }
+
+  response.writeHead(404, { "content-type": "text/plain; charset=utf-8" });
+  response.end("Not found");
+});
+
+server.listen(port, "127.0.0.1", () => {
+  process.stdout.write(`site-monitor dashboard listening on http://127.0.0.1:${port}\n`);
+});

--- a/src/dashboard-data.mjs
+++ b/src/dashboard-data.mjs
@@ -1,0 +1,110 @@
+const ENVIRONMENTS = ["production", "staging", "edge"];
+const TAGS = ["checkout", "api", "search", "auth", "catalog"];
+const STATUSES = ["healthy", "healthy", "healthy", "healthy", "degraded", "incident", "paused"];
+const INCIDENT_STATES = ["none", "none", "none", "watching", "open"];
+
+function pad(value) {
+  return String(value).padStart(3, "0");
+}
+
+function createMonitor(index) {
+  const environment = ENVIRONMENTS[index % ENVIRONMENTS.length];
+  const tag = TAGS[index % TAGS.length];
+  const status = STATUSES[index % STATUSES.length];
+  const incidentState =
+    status === "incident" ? "open" : INCIDENT_STATES[(index + 2) % INCIDENT_STATES.length];
+  const latencyMs = 182 + ((index * 37) % 380);
+  const availability30d = status === "incident" ? 97.42 : Math.min(99.99, 98.62 + ((index * 17) % 118) / 100);
+  const checks30d = 720;
+  const incidents30d = status === "incident" ? 1 + (index % 3) : index % 2;
+
+  return {
+    id: `mon-${pad(index + 1)}`,
+    name: `${tag}-${environment}-${pad(index + 1)}`,
+    environment,
+    status,
+    tag,
+    incidentState,
+    latencyMs,
+    availability30d: Number(availability30d.toFixed(2)),
+    checks30d,
+    incidents30d,
+    lastCheckedAt: `${(index % 8) + 1}m ago`,
+    nextRunAt: `${(index % 5) + 1}m`,
+    sparkline: [0, 1, 1, 1, 1, status === "incident" ? 0 : 1, 1, 1]
+  };
+}
+
+function createIncident(monitor, index) {
+  return {
+    id: `INC-${420 + index}`,
+    monitorName: monitor.name,
+    environment: monitor.environment,
+    age: `${14 + (index * 7)}m`,
+    severity: index % 2 === 0 ? "critical" : "elevated",
+    summary:
+      index % 2 === 0
+        ? `Latency breach on ${monitor.tag} path over 30-day baseline`
+        : `Availability dip persisted past threshold`,
+    owner: index % 3 === 0 ? "On-call SRE" : "Unassigned"
+  };
+}
+
+export function createDashboardData() {
+  const monitors = Array.from({ length: 180 }, (_, index) => createMonitor(index));
+  const openIncidentMonitors = monitors.filter((monitor) => monitor.status === "incident").slice(0, 8);
+  const summary = monitors.reduce(
+    (accumulator, monitor) => {
+      accumulator.total += 1;
+      accumulator[monitor.status] += 1;
+      if (monitor.incidentState === "open") {
+        accumulator.openIncidents += 1;
+      }
+      return accumulator;
+    },
+    {
+      total: 0,
+      healthy: 0,
+      degraded: 0,
+      incident: 0,
+      paused: 0,
+      openIncidents: 0
+    }
+  );
+
+  return {
+    generatedAt: "2026-04-06T00:00:00.000Z",
+    dataset: {
+      spanDays: 30,
+      monitorCount: monitors.length,
+      checksPerMonitor: 720
+    },
+    filters: {
+      environments: ENVIRONMENTS,
+      statuses: ["all", "healthy", "degraded", "incident", "paused"],
+      tags: ["all", ...TAGS],
+      incidentStates: ["all", "none", "watching", "open"]
+    },
+    summary,
+    incidents: openIncidentMonitors.map((monitor, index) => createIncident(monitor, index)),
+    monitors
+  };
+}
+
+export function filterMonitors(monitors, filters) {
+  return monitors.filter((monitor) => {
+    if (filters.environment !== "all" && monitor.environment !== filters.environment) {
+      return false;
+    }
+    if (filters.status !== "all" && monitor.status !== filters.status) {
+      return false;
+    }
+    if (filters.tag !== "all" && monitor.tag !== filters.tag) {
+      return false;
+    }
+    if (filters.incidentState !== "all" && monitor.incidentState !== filters.incidentState) {
+      return false;
+    }
+    return true;
+  });
+}

--- a/src/dashboard-page.mjs
+++ b/src/dashboard-page.mjs
@@ -1,0 +1,769 @@
+import { createDashboardData, filterMonitors } from "./dashboard-data.mjs";
+
+const ROW_LIMIT = 12;
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function metricCard(label, value, tone, detail) {
+  return `
+    <article class="metric metric-${tone}">
+      <p class="metric-label">${escapeHtml(label)}</p>
+      <p class="metric-value">${escapeHtml(value)}</p>
+      <p class="metric-detail">${escapeHtml(detail)}</p>
+    </article>
+  `;
+}
+
+function renderSummary(summary, dataset) {
+  return `
+    <section class="metrics" aria-label="Dashboard summary">
+      ${metricCard("Healthy", summary.healthy, "healthy", `${dataset.monitorCount} monitors in 30-day slice`)}
+      ${metricCard("Degraded", summary.degraded, "degraded", "Elevated latency or reduced headroom")}
+      ${metricCard("Open incidents", summary.openIncidents, "incident", "Actionable failures across environments")}
+      ${metricCard("Paused", summary.paused, "paused", "Excluded from active checks")}
+    </section>
+  `;
+}
+
+function renderFilterSelect(id, label, options, selected) {
+  const optionMarkup = options
+    .map((option) => {
+      const value = option === "all" ? "all" : option;
+      const isSelected = value === selected ? " selected" : "";
+      return `<option value="${escapeHtml(value)}"${isSelected}>${escapeHtml(option)}</option>`;
+    })
+    .join("");
+
+  return `
+    <label class="filter-field" for="${escapeHtml(id)}">
+      <span>${escapeHtml(label)}</span>
+      <select id="${escapeHtml(id)}" name="${escapeHtml(id)}">${optionMarkup}</select>
+    </label>
+  `;
+}
+
+function renderFilters(filters, selected) {
+  return `
+    <section class="filters" aria-label="Monitor filters">
+      ${renderFilterSelect("environment", "Environment", ["all", ...filters.environments], selected.environment)}
+      ${renderFilterSelect("status", "Status", filters.statuses, selected.status)}
+      ${renderFilterSelect("tag", "Tag", filters.tags, selected.tag)}
+      ${renderFilterSelect("incidentState", "Incident state", filters.incidentStates, selected.incidentState)}
+    </section>
+  `;
+}
+
+function renderSparkline(points) {
+  return points
+    .map((point, index) => {
+      const height = point === 0 ? 22 : 42;
+      return `<span class="spark-bar" style="height:${height}px" aria-hidden="true"></span>`;
+    })
+    .join("");
+}
+
+function renderMonitorRows(monitors) {
+  if (!monitors.length) {
+    return `
+      <tr>
+        <td colspan="7" class="empty-state">No monitors match the current filter combination.</td>
+      </tr>
+    `;
+  }
+
+  return monitors
+    .slice(0, ROW_LIMIT)
+    .map(
+      (monitor) => `
+        <tr>
+          <td>
+            <p class="row-title">${escapeHtml(monitor.name)}</p>
+            <p class="row-meta">${escapeHtml(monitor.environment)} · ${escapeHtml(monitor.tag)}</p>
+          </td>
+          <td><span class="status-pill status-${escapeHtml(monitor.status)}">${escapeHtml(monitor.status)}</span></td>
+          <td>${escapeHtml(`${monitor.latencyMs} ms`)}</td>
+          <td>${escapeHtml(`${monitor.availability30d}%`)}</td>
+          <td>${escapeHtml(String(monitor.incidents30d))}</td>
+          <td>${escapeHtml(monitor.lastCheckedAt)}</td>
+          <td>
+            <div class="sparkline" aria-label="Recent monitor health">
+              ${renderSparkline(monitor.sparkline)}
+            </div>
+          </td>
+        </tr>
+      `
+    )
+    .join("");
+}
+
+function renderIncidents(incidents) {
+  return incidents
+    .map(
+      (incident) => `
+        <article class="incident-card">
+          <div class="incident-head">
+            <p class="incident-id">${escapeHtml(incident.id)}</p>
+            <span class="severity-pill severity-${escapeHtml(incident.severity)}">${escapeHtml(incident.severity)}</span>
+          </div>
+          <p class="incident-monitor">${escapeHtml(incident.monitorName)}</p>
+          <p class="incident-summary">${escapeHtml(incident.summary)}</p>
+          <dl class="incident-meta">
+            <div><dt>Age</dt><dd>${escapeHtml(incident.age)}</dd></div>
+            <div><dt>Owner</dt><dd>${escapeHtml(incident.owner)}</dd></div>
+          </dl>
+        </article>
+      `
+    )
+    .join("");
+}
+
+function renderPageContent(data, selectedFilters) {
+  const filtered = filterMonitors(data.monitors, selectedFilters);
+
+  return `
+    ${renderSummary(data.summary, data.dataset)}
+    ${renderFilters(data.filters, selectedFilters)}
+    <section class="content-grid">
+      <section class="panel panel-table" aria-labelledby="monitor-heading">
+        <div class="panel-head">
+          <div>
+            <p class="eyebrow">Primary content</p>
+            <h2 id="monitor-heading">Monitor overview</h2>
+          </div>
+          <p class="panel-detail">${escapeHtml(`${filtered.length} matching monitors · first ${Math.min(filtered.length, ROW_LIMIT)} shown`)}</p>
+        </div>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Monitor</th>
+                <th>Status</th>
+                <th>P95 latency</th>
+                <th>30-day availability</th>
+                <th>Incidents</th>
+                <th>Last check</th>
+                <th>Health</th>
+              </tr>
+            </thead>
+            <tbody id="monitor-rows">${renderMonitorRows(filtered)}</tbody>
+          </table>
+        </div>
+      </section>
+      <aside class="panel panel-incidents" aria-labelledby="incident-heading">
+        <div class="panel-head">
+          <div>
+            <p class="eyebrow">Triage</p>
+            <h2 id="incident-heading">Open incidents</h2>
+          </div>
+          <p class="panel-detail">${escapeHtml(`${data.incidents.length} active incidents`)}</p>
+        </div>
+        <div id="incident-list" class="incident-list">
+          ${renderIncidents(data.incidents)}
+        </div>
+      </aside>
+    </section>
+  `;
+}
+
+function renderStyles() {
+  return `
+    :root {
+      color-scheme: light;
+      --bg: #f4efe7;
+      --surface: rgba(255, 250, 243, 0.88);
+      --surface-strong: #fff7ee;
+      --ink: #17231f;
+      --muted: #556663;
+      --line: rgba(23, 35, 31, 0.1);
+      --healthy: #1e7a59;
+      --degraded: #a65a18;
+      --incident: #ba2d1d;
+      --paused: #426b84;
+      --accent: #0d4f63;
+      --shadow: 0 24px 54px rgba(23, 35, 31, 0.08);
+      font-family: "IBM Plex Sans", "Avenir Next", "Segoe UI", sans-serif;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      color: var(--ink);
+      background:
+        radial-gradient(circle at top left, rgba(240, 151, 87, 0.3), transparent 34%),
+        radial-gradient(circle at top right, rgba(41, 102, 130, 0.14), transparent 28%),
+        linear-gradient(180deg, #f7f2e9 0%, var(--bg) 100%);
+    }
+
+    .shell {
+      width: min(1180px, calc(100vw - 32px));
+      margin: 0 auto;
+      padding: 28px 0 40px;
+    }
+
+    .masthead {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 16px;
+      align-items: end;
+      margin-bottom: 20px;
+    }
+
+    .brand {
+      display: flex;
+      gap: 12px;
+      align-items: center;
+    }
+
+    .brand-mark {
+      width: 54px;
+      height: 54px;
+      border-radius: 18px;
+      display: grid;
+      place-items: center;
+      font-size: 24px;
+      color: #fff;
+      background: linear-gradient(135deg, #194d5d 0%, #ee8654 100%);
+      box-shadow: var(--shadow);
+    }
+
+    .brand-copy h1,
+    .brand-copy p,
+    .hero h2,
+    .hero p {
+      margin: 0;
+    }
+
+    .brand-copy h1 {
+      font-size: clamp(2rem, 5vw, 3.1rem);
+      line-height: 0.95;
+      letter-spacing: -0.06em;
+    }
+
+    .brand-copy p {
+      margin-top: 6px;
+      color: var(--muted);
+      font-size: 0.96rem;
+    }
+
+    .hero {
+      justify-self: end;
+      max-width: 420px;
+      padding: 18px 20px;
+      border: 1px solid rgba(13, 79, 99, 0.12);
+      border-radius: 24px;
+      background: rgba(255, 248, 238, 0.7);
+      box-shadow: var(--shadow);
+    }
+
+    .hero h2 {
+      font-size: 1.1rem;
+      margin-bottom: 6px;
+    }
+
+    .hero p {
+      color: var(--muted);
+      line-height: 1.5;
+    }
+
+    .metrics,
+    .filters,
+    .content-grid {
+      opacity: 0;
+      transform: translateY(12px);
+      animation: settle 420ms ease-out forwards;
+    }
+
+    .filters {
+      animation-delay: 90ms;
+    }
+
+    .content-grid {
+      animation-delay: 160ms;
+    }
+
+    @keyframes settle {
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+
+    .metrics {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 14px;
+      margin-bottom: 14px;
+    }
+
+    .metric,
+    .panel,
+    .filters {
+      border: 1px solid var(--line);
+      border-radius: 24px;
+      background: var(--surface);
+      box-shadow: var(--shadow);
+      backdrop-filter: blur(10px);
+    }
+
+    .metric {
+      padding: 18px 20px;
+    }
+
+    .metric-label,
+    .metric-detail,
+    .eyebrow,
+    .panel-detail,
+    .row-meta,
+    .incident-summary,
+    .incident-meta,
+    .filter-field span {
+      color: var(--muted);
+    }
+
+    .metric-label,
+    .metric-value,
+    .metric-detail,
+    .eyebrow,
+    .panel-detail,
+    .row-title,
+    .row-meta,
+    .incident-id,
+    .incident-monitor,
+    .incident-summary {
+      margin: 0;
+    }
+
+    .metric-value {
+      margin-top: 10px;
+      font-size: clamp(2rem, 4vw, 2.9rem);
+      line-height: 0.95;
+      letter-spacing: -0.08em;
+    }
+
+    .metric-detail {
+      margin-top: 10px;
+      line-height: 1.45;
+    }
+
+    .metric-healthy {
+      background: linear-gradient(180deg, rgba(238, 251, 244, 0.95) 0%, rgba(255, 250, 243, 0.88) 100%);
+    }
+
+    .metric-degraded {
+      background: linear-gradient(180deg, rgba(255, 241, 226, 0.95) 0%, rgba(255, 250, 243, 0.88) 100%);
+    }
+
+    .metric-incident {
+      background: linear-gradient(180deg, rgba(255, 233, 226, 0.98) 0%, rgba(255, 250, 243, 0.9) 100%);
+    }
+
+    .metric-paused {
+      background: linear-gradient(180deg, rgba(233, 243, 249, 0.98) 0%, rgba(255, 250, 243, 0.9) 100%);
+    }
+
+    .filters {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 12px;
+      padding: 16px;
+      margin-bottom: 14px;
+    }
+
+    .filter-field {
+      display: grid;
+      gap: 8px;
+      font-size: 0.92rem;
+    }
+
+    .filter-field select {
+      width: 100%;
+      border: 1px solid rgba(23, 35, 31, 0.16);
+      border-radius: 14px;
+      padding: 12px 14px;
+      color: var(--ink);
+      background: var(--surface-strong);
+      font: inherit;
+    }
+
+    .content-grid {
+      display: grid;
+      grid-template-columns: minmax(0, 2.1fr) minmax(300px, 0.95fr);
+      gap: 14px;
+    }
+
+    .panel {
+      padding: 18px;
+    }
+
+    .panel-head {
+      display: flex;
+      justify-content: space-between;
+      gap: 16px;
+      align-items: end;
+      margin-bottom: 16px;
+    }
+
+    .panel-head h2 {
+      margin: 4px 0 0;
+      font-size: 1.38rem;
+      letter-spacing: -0.04em;
+    }
+
+    .table-wrap {
+      overflow: auto;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+
+    th,
+    td {
+      padding: 13px 10px;
+      text-align: left;
+      border-bottom: 1px solid rgba(23, 35, 31, 0.08);
+      vertical-align: middle;
+      white-space: nowrap;
+    }
+
+    th {
+      font-size: 0.82rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--muted);
+    }
+
+    .row-title {
+      font-weight: 700;
+    }
+
+    .row-meta {
+      margin-top: 4px;
+      font-size: 0.88rem;
+    }
+
+    .status-pill,
+    .severity-pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      border-radius: 999px;
+      padding: 6px 10px;
+      font-size: 0.84rem;
+      font-weight: 700;
+      text-transform: capitalize;
+    }
+
+    .status-healthy {
+      color: var(--healthy);
+      background: rgba(30, 122, 89, 0.12);
+    }
+
+    .status-degraded {
+      color: var(--degraded);
+      background: rgba(166, 90, 24, 0.12);
+    }
+
+    .status-incident,
+    .severity-critical {
+      color: var(--incident);
+      background: rgba(186, 45, 29, 0.12);
+    }
+
+    .status-paused,
+    .severity-elevated {
+      color: var(--paused);
+      background: rgba(66, 107, 132, 0.14);
+    }
+
+    .sparkline {
+      display: flex;
+      align-items: end;
+      gap: 4px;
+      min-height: 42px;
+    }
+
+    .spark-bar {
+      width: 6px;
+      border-radius: 999px;
+      background: linear-gradient(180deg, #1f7463 0%, #ee8654 100%);
+    }
+
+    .incident-list {
+      display: grid;
+      gap: 12px;
+    }
+
+    .incident-card {
+      padding: 14px;
+      border: 1px solid rgba(23, 35, 31, 0.08);
+      border-radius: 18px;
+      background: rgba(255, 252, 247, 0.96);
+    }
+
+    .incident-head {
+      display: flex;
+      justify-content: space-between;
+      gap: 12px;
+      align-items: center;
+      margin-bottom: 10px;
+    }
+
+    .incident-id {
+      font-weight: 800;
+      letter-spacing: 0.06em;
+      font-size: 0.82rem;
+    }
+
+    .incident-monitor {
+      font-weight: 700;
+    }
+
+    .incident-summary {
+      margin-top: 6px;
+      line-height: 1.5;
+    }
+
+    .incident-meta {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 10px;
+      margin: 12px 0 0;
+      font-size: 0.9rem;
+    }
+
+    .incident-meta div,
+    .incident-meta dt,
+    .incident-meta dd {
+      margin: 0;
+    }
+
+    .empty-state {
+      color: var(--muted);
+      text-align: center;
+      padding: 28px 14px;
+    }
+
+    .visually-hidden {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
+
+    @media (max-width: 980px) {
+      .masthead,
+      .content-grid {
+        grid-template-columns: 1fr;
+      }
+
+      .hero {
+        justify-self: stretch;
+        max-width: none;
+      }
+
+      .metrics,
+      .filters {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+    }
+
+    @media (max-width: 640px) {
+      .shell {
+        width: min(100vw - 18px, 100%);
+        padding-top: 18px;
+      }
+
+      .metrics,
+      .filters {
+        grid-template-columns: 1fr;
+      }
+
+      .metric,
+      .panel,
+      .filters {
+        border-radius: 20px;
+      }
+
+      .panel-head {
+        flex-direction: column;
+        align-items: start;
+      }
+
+      th:nth-child(4),
+      td:nth-child(4),
+      th:nth-child(7),
+      td:nth-child(7) {
+        display: none;
+      }
+    }
+  `;
+}
+
+function renderClientScript() {
+  return `
+    (() => {
+      const data = JSON.parse(document.getElementById("dashboard-data").textContent);
+      const rowLimit = ${ROW_LIMIT};
+      const monitorRows = document.getElementById("monitor-rows");
+      const incidentList = document.getElementById("incident-list");
+      const filterInputs = {
+        environment: document.getElementById("environment"),
+        status: document.getElementById("status"),
+        tag: document.getElementById("tag"),
+        incidentState: document.getElementById("incidentState")
+      };
+      const panelDetail = document.querySelector(".panel-table .panel-detail");
+
+      function escapeHtml(value) {
+        return String(value)
+          .replaceAll("&", "&amp;")
+          .replaceAll("<", "&lt;")
+          .replaceAll(">", "&gt;")
+          .replaceAll('"', "&quot;")
+          .replaceAll("'", "&#39;");
+      }
+
+      function renderSparkline(points) {
+        return points
+          .map((point) => {
+            const height = point === 0 ? 22 : 42;
+            return '<span class="spark-bar" style="height:' + height + 'px" aria-hidden="true"></span>';
+          })
+          .join("");
+      }
+
+      function filterMonitors(monitors, filters) {
+        return monitors.filter((monitor) => {
+          if (filters.environment !== "all" && monitor.environment !== filters.environment) return false;
+          if (filters.status !== "all" && monitor.status !== filters.status) return false;
+          if (filters.tag !== "all" && monitor.tag !== filters.tag) return false;
+          if (filters.incidentState !== "all" && monitor.incidentState !== filters.incidentState) return false;
+          return true;
+        });
+      }
+
+      function renderRows(monitors) {
+        if (!monitors.length) {
+          return '<tr><td colspan="7" class="empty-state">No monitors match the current filter combination.</td></tr>';
+        }
+
+        return monitors.slice(0, rowLimit).map((monitor) => {
+          return [
+            "<tr>",
+            "<td><p class=\\"row-title\\">" + escapeHtml(monitor.name) + "</p><p class=\\"row-meta\\">" + escapeHtml(monitor.environment + " · " + monitor.tag) + "</p></td>",
+            "<td><span class=\\"status-pill status-" + escapeHtml(monitor.status) + "\\">" + escapeHtml(monitor.status) + "</span></td>",
+            "<td>" + escapeHtml(monitor.latencyMs + " ms") + "</td>",
+            "<td>" + escapeHtml(monitor.availability30d + "%") + "</td>",
+            "<td>" + escapeHtml(String(monitor.incidents30d)) + "</td>",
+            "<td>" + escapeHtml(monitor.lastCheckedAt) + "</td>",
+            "<td><div class=\\"sparkline\\" aria-label=\\"Recent monitor health\\">" + renderSparkline(monitor.sparkline) + "</div></td>",
+            "</tr>"
+          ].join("");
+        }).join("");
+      }
+
+      function renderIncidents(incidents) {
+        return incidents.map((incident) => {
+          return [
+            "<article class=\\"incident-card\\">",
+            "<div class=\\"incident-head\\"><p class=\\"incident-id\\">" + escapeHtml(incident.id) + "</p><span class=\\"severity-pill severity-" + escapeHtml(incident.severity) + "\\">" + escapeHtml(incident.severity) + "</span></div>",
+            "<p class=\\"incident-monitor\\">" + escapeHtml(incident.monitorName) + "</p>",
+            "<p class=\\"incident-summary\\">" + escapeHtml(incident.summary) + "</p>",
+            "<dl class=\\"incident-meta\\">",
+            "<div><dt>Age</dt><dd>" + escapeHtml(incident.age) + "</dd></div>",
+            "<div><dt>Owner</dt><dd>" + escapeHtml(incident.owner) + "</dd></div>",
+            "</dl>",
+            "</article>"
+          ].join("");
+        }).join("");
+      }
+
+      function update() {
+        const selected = {
+          environment: filterInputs.environment.value,
+          status: filterInputs.status.value,
+          tag: filterInputs.tag.value,
+          incidentState: filterInputs.incidentState.value
+        };
+        const filtered = filterMonitors(data.monitors, selected);
+        monitorRows.innerHTML = renderRows(filtered);
+        panelDetail.textContent = filtered.length + " matching monitors · first " + Math.min(filtered.length, rowLimit) + " shown";
+      }
+
+      Object.values(filterInputs).forEach((input) => {
+        input.addEventListener("change", update, { passive: true });
+      });
+
+      requestIdleCallback?.(() => {
+        incidentList.innerHTML = renderIncidents(data.incidents);
+      }, { timeout: 400 });
+    })();
+  `;
+}
+
+export function renderDashboardPage() {
+  const data = createDashboardData();
+  const selectedFilters = {
+    environment: "all",
+    status: "all",
+    tag: "all",
+    incidentState: "all"
+  };
+
+  return `
+    <!DOCTYPE html>
+    <html lang="en">
+      <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>site-monitor dashboard</title>
+        <meta
+          name="description"
+          content="Operational dashboard optimized for fast first render on a 30-day dataset slice."
+        >
+        <style>${renderStyles()}</style>
+      </head>
+      <body>
+        <main class="shell">
+          <header class="masthead">
+            <div class="brand">
+              <div class="brand-mark" aria-hidden="true">S</div>
+              <div class="brand-copy">
+                <p>site-monitor</p>
+                <h1>Dashboard under load.</h1>
+              </div>
+            </div>
+            <section class="hero" aria-label="Performance note">
+              <h2>30-day slice, rendered first</h2>
+              <p>
+                Summary tiles, incident queue, and the first page of monitor rows ship in the initial document.
+                Filtering stays client-side so the primary content is visible before any enhancement work.
+              </p>
+            </section>
+          </header>
+          ${renderPageContent(data, selectedFilters)}
+        </main>
+        <script id="dashboard-data" type="application/json">${escapeHtml(JSON.stringify(data))}</script>
+        <script>${renderClientScript()}</script>
+      </body>
+    </html>
+  `.trim();
+}

--- a/test/dashboard.test.mjs
+++ b/test/dashboard.test.mjs
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createDashboardData, filterMonitors } from "../src/dashboard-data.mjs";
+import { renderDashboardPage } from "../src/dashboard-page.mjs";
+
+test("dashboard fixture represents a 30-day dataset slice", () => {
+  const data = createDashboardData();
+
+  assert.equal(data.dataset.spanDays, 30);
+  assert.equal(data.monitors.length, 180);
+  assert.equal(data.dataset.monitorCount, data.monitors.length);
+});
+
+test("summary counts stay aligned with monitor records", () => {
+  const data = createDashboardData();
+  const countedStatuses =
+    data.summary.healthy + data.summary.degraded + data.summary.incident + data.summary.paused;
+
+  assert.equal(countedStatuses, data.monitors.length);
+  assert.ok(data.summary.openIncidents >= data.incidents.length);
+  assert.ok(data.incidents.every((incident) => incident.id.startsWith("INC-")));
+});
+
+test("filters reduce the monitor list without mutating the source dataset", () => {
+  const data = createDashboardData();
+  const originalLength = data.monitors.length;
+  const filtered = filterMonitors(data.monitors, {
+    environment: "production",
+    status: "incident",
+    tag: "catalog",
+    incidentState: "open"
+  });
+
+  assert.ok(filtered.length > 0);
+  assert.ok(filtered.every((monitor) => monitor.environment === "production"));
+  assert.ok(filtered.every((monitor) => monitor.status === "incident"));
+  assert.ok(filtered.every((monitor) => monitor.tag === "catalog"));
+  assert.ok(filtered.every((monitor) => monitor.incidentState === "open"));
+  assert.equal(data.monitors.length, originalLength);
+});
+
+test("server-rendered dashboard keeps the initial payload within budget", () => {
+  const html = renderDashboardPage();
+  const bytes = Buffer.byteLength(html, "utf8");
+
+  assert.match(html, /<section class="metrics"/);
+  assert.match(html, /<tbody id="monitor-rows">/);
+  assert.match(html, /<div id="incident-list" class="incident-list">/);
+  assert.ok(bytes < 140000, `expected HTML payload under 140000 bytes, received ${bytes}`);
+});


### PR DESCRIPTION
Summary
- advance issue #8 with a dashboard-only implementation optimized for fast first render on a 30-day dataset slice
- server-render the primary dashboard content in the initial HTML and keep filter updates client-side without a full reload
- add local budget checks plus a reproducible Lighthouse runner that uses temporary tooling instead of adding permanent browser dependencies to the repo

Tests
- npm test
- npm run perf:budget

Reviewer Verify
- run npm start and open the dashboard to confirm summary tiles, open incidents, and first-page monitor rows are present immediately
- run npm test and npm run perf:budget
- if the host has Chrome runtime libraries available, run npm exec --yes --package=puppeteer --package=lighthouse --package=chrome-launcher node scripts/lighthouse-profile.mjs

Notes
- advances #8 without closing it
- attempted browser-based verification in this environment, but the host is missing shared libraries required to launch Chrome