### PR TITLE
[NFR-007] Implement mobile-first dashboard and incident triage slice

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,128 @@
+const menuToggle = document.querySelector("[data-menu-toggle]");
+const menu = document.querySelector("[data-menu]");
+
+if (menuToggle && menu) {
+  menuToggle.addEventListener("click", () => {
+    const expanded = menuToggle.getAttribute("aria-expanded") === "true";
+    menuToggle.setAttribute("aria-expanded", String(!expanded));
+    menu.classList.toggle("is-open", !expanded);
+  });
+}
+
+const filtersToggle = document.querySelector("[data-filters-toggle]");
+const filters = document.querySelector("[data-filters]");
+
+if (filtersToggle && filters) {
+  filtersToggle.addEventListener("click", () => {
+    const expanded = filtersToggle.getAttribute("aria-expanded") === "true";
+    filtersToggle.setAttribute("aria-expanded", String(!expanded));
+    filters.classList.toggle("is-open", !expanded);
+  });
+}
+
+const monitorList = document.querySelector("[data-monitor-list]");
+const resultsCount = document.querySelector("[data-results-count]");
+
+if (monitorList && filters) {
+  const applyFilters = () => {
+    const formData = new FormData(filters);
+    const rules = {
+      environment: formData.get("environment"),
+      status: formData.get("status"),
+      incident: formData.get("incident"),
+    };
+
+    let visibleCount = 0;
+
+    for (const card of monitorList.children) {
+      const matches = Object.entries(rules).every(([key, value]) => {
+        if (!value || value === "all") {
+          return true;
+        }
+
+        return card.dataset[key] === value;
+      });
+
+      card.classList.toggle("is-hidden", !matches);
+
+      if (matches) {
+        visibleCount += 1;
+      }
+    }
+
+    if (resultsCount) {
+      const noun = visibleCount === 1 ? "monitor" : "monitors";
+      resultsCount.textContent = `Showing ${visibleCount} ${noun}`;
+    }
+  };
+
+  filters.addEventListener("change", applyFilters);
+  filters.addEventListener("reset", () => {
+    window.setTimeout(applyFilters, 0);
+  });
+}
+
+const incidentBadge = document.querySelector("[data-incident-state-badge]");
+const deliveryState = document.querySelector("[data-delivery-state]");
+const responder = document.querySelector("[data-responder]");
+const noteField = document.querySelector("[data-note]");
+const timeline = document.querySelector("[data-timeline]");
+
+const appendTimelineEvent = (title, detail) => {
+  if (!timeline) {
+    return;
+  }
+
+  const item = document.createElement("li");
+  item.className = "timeline-item";
+
+  const time = new Date().toISOString().slice(11, 16);
+
+  item.innerHTML = `
+    <span class="timeline-time">${time} UTC</span>
+    <div>
+      <h3>${title}</h3>
+      <p>${detail}</p>
+    </div>
+  `;
+
+  timeline.prepend(item);
+};
+
+document.querySelectorAll("[data-action]").forEach((button) => {
+  button.addEventListener("click", () => {
+    const note = noteField?.value.trim() || "No note supplied.";
+
+    switch (button.dataset.action) {
+      case "acknowledge":
+        if (incidentBadge) {
+          incidentBadge.textContent = "Acknowledged";
+          incidentBadge.className = "pill pill-degraded";
+        }
+
+        if (responder) {
+          responder.textContent = "Primary on-call";
+        }
+
+        appendTimelineEvent("Incident acknowledged", note);
+        break;
+      case "mute":
+        if (deliveryState) {
+          deliveryState.textContent = "muted";
+        }
+
+        appendTimelineEvent("Alerts muted", note);
+        break;
+      case "resolve":
+        if (incidentBadge) {
+          incidentBadge.textContent = "Resolved";
+          incidentBadge.className = "pill pill-healthy";
+        }
+
+        appendTimelineEvent("Incident resolved", note);
+        break;
+      default:
+        break;
+    }
+  });
+});

--- a/docs/qa/mobile-support-checklist.md
+++ b/docs/qa/mobile-support-checklist.md
@@ -1,0 +1,16 @@
+# Mobile Support QA Checklist
+
+Issue: [#12](https://github.com/IDNTEQ/site-monitor/issues/12)
+
+## Target
+
+Validate that the dashboard and incident triage pages remain usable at 375px width and above.
+
+## Manual QA
+
+1. Open `index.html` at 375px width and confirm summary cards, filters, open incidents, and monitor cards fit without horizontal scrolling.
+2. Toggle the mobile menu and the filter drawer on `index.html`; confirm both remain keyboard and touch reachable.
+3. Apply each dashboard filter and confirm monitor cards update while the results count stays accurate.
+4. Open `incident.html` at 375px width and confirm the action buttons stack cleanly above the evidence and timeline panels.
+5. Trigger acknowledge, mute, and resolve actions on `incident.html`; confirm the state badge and timeline update without clipping or overlap.
+6. Repeat the above at tablet and desktop widths to confirm the layout expands back to multi-column grids.

--- a/incident.html
+++ b/incident.html
@@ -1,0 +1,197 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>site-monitor | Incident INC-204</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body data-page="incident">
+    <div class="app-shell">
+      <header class="topbar">
+        <div>
+          <p class="eyebrow">Incident Triage</p>
+          <a class="brand" href="./index.html">site-monitor</a>
+        </div>
+        <button
+          class="menu-toggle"
+          type="button"
+          aria-expanded="false"
+          aria-controls="primary-nav"
+          data-menu-toggle
+        >
+          Menu
+        </button>
+        <nav class="nav-links" id="primary-nav" data-menu>
+          <a class="nav-link" href="./index.html">Dashboard</a>
+          <a class="nav-link is-active" href="./incident.html">Incident</a>
+          <a class="nav-link" href="./index.html#monitors">Monitors</a>
+        </nav>
+      </header>
+
+      <main class="page incident-page">
+        <section class="hero-card incident-hero">
+          <div>
+            <p class="eyebrow">Open incident</p>
+            <div class="incident-title-row">
+              <h1>INC-204 checkout latency spike</h1>
+              <span class="pill pill-incident" data-incident-state-badge>Open</span>
+            </div>
+            <p class="hero-copy">
+              checkout.example.com breached the latency threshold 18 minutes ago.
+              Recent checks show elevated response times and intermittent 502s.
+            </p>
+          </div>
+          <div class="hero-metrics">
+            <div class="hero-metric">
+              <span>Monitor</span>
+              <strong>checkout.example.com</strong>
+            </div>
+            <div class="hero-metric">
+              <span>Priority</span>
+              <strong>P1</strong>
+            </div>
+            <div class="hero-metric">
+              <span>Responder</span>
+              <strong data-responder>Unassigned</strong>
+            </div>
+          </div>
+        </section>
+
+        <section class="sticky-actions panel">
+          <div class="panel-heading">
+            <div>
+              <p class="eyebrow">Actions</p>
+              <h2>Touch-sized controls stay visible while scrolling.</h2>
+            </div>
+            <a class="text-link" href="./index.html">Back to dashboard</a>
+          </div>
+
+          <div class="action-grid">
+            <button class="primary-button" type="button" data-action="acknowledge">
+              Acknowledge incident
+            </button>
+            <button class="secondary-button" type="button" data-action="mute">
+              Mute alerts
+            </button>
+            <button class="secondary-button" type="button" data-action="resolve">
+              Resolve incident
+            </button>
+          </div>
+
+          <label class="note-field">
+            <span>Operator note</span>
+            <textarea
+              data-note
+              rows="3"
+              placeholder="Add context for the next responder."
+            ></textarea>
+          </label>
+        </section>
+
+        <section class="incident-layout">
+          <article class="panel">
+            <div class="panel-heading">
+              <div>
+                <p class="eyebrow">Latest evidence</p>
+                <h2>Failure details remain readable without horizontal scroll.</h2>
+              </div>
+            </div>
+
+            <div class="evidence-list">
+              <article class="evidence-card">
+                <div>
+                  <h3>Latest failed check</h3>
+                  <p>00:18 UTC · 502 Bad Gateway · 7.3s response time</p>
+                </div>
+                <span class="pill pill-incident">failed</span>
+              </article>
+              <article class="evidence-card">
+                <div>
+                  <h3>Expected threshold</h3>
+                  <p>Alert after 3 consecutive failures or p95 latency over 2.0s</p>
+                </div>
+                <span class="pill pill-degraded">policy</span>
+              </article>
+              <article class="evidence-card">
+                <div>
+                  <h3>Delivery state</h3>
+                  <p>PagerDuty triggered, Slack posted, email pending retry</p>
+                </div>
+                <span class="pill pill-muted" data-delivery-state>not muted</span>
+              </article>
+            </div>
+          </article>
+
+          <article class="panel">
+            <div class="panel-heading">
+              <div>
+                <p class="eyebrow">Timeline</p>
+                <h2>Incident events stay in source order for narrow screens.</h2>
+              </div>
+            </div>
+
+            <ol class="timeline" data-timeline>
+              <li class="timeline-item">
+                <span class="timeline-time">00:00 UTC</span>
+                <div>
+                  <h3>Incident opened automatically</h3>
+                  <p>Threshold crossed after 3 failed checks.</p>
+                </div>
+              </li>
+              <li class="timeline-item">
+                <span class="timeline-time">00:01 UTC</span>
+                <div>
+                  <h3>PagerDuty notification sent</h3>
+                  <p>Primary on-call rotation acknowledged receipt.</p>
+                </div>
+              </li>
+              <li class="timeline-item">
+                <span class="timeline-time">00:09 UTC</span>
+                <div>
+                  <h3>Response time increased again</h3>
+                  <p>p95 climbed to 6.8s after a short recovery window.</p>
+                </div>
+              </li>
+            </ol>
+          </article>
+
+          <article class="panel">
+            <div class="panel-heading">
+              <div>
+                <p class="eyebrow">Recent checks</p>
+                <h2>Compact cards replace a wide results table on mobile.</h2>
+              </div>
+            </div>
+
+            <div class="check-list">
+              <article class="check-card">
+                <span class="pill pill-incident">00:18</span>
+                <div>
+                  <h3>502 Bad Gateway</h3>
+                  <p>7.3s · rule: response under 2.0s</p>
+                </div>
+              </article>
+              <article class="check-card">
+                <span class="pill pill-incident">00:17</span>
+                <div>
+                  <h3>504 Gateway Timeout</h3>
+                  <p>8.0s · upstream connection timed out</p>
+                </div>
+              </article>
+              <article class="check-card">
+                <span class="pill pill-degraded">00:16</span>
+                <div>
+                  <h3>200 OK</h3>
+                  <p>2.4s · above latency threshold</p>
+                </div>
+              </article>
+            </div>
+          </article>
+        </section>
+      </main>
+    </div>
+
+    <script src="./app.js"></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,326 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>site-monitor | Dashboard</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body data-page="dashboard">
+    <div class="app-shell">
+      <header class="topbar">
+        <div>
+          <p class="eyebrow">Operator Console</p>
+          <a class="brand" href="./index.html">site-monitor</a>
+        </div>
+        <button
+          class="menu-toggle"
+          type="button"
+          aria-expanded="false"
+          aria-controls="primary-nav"
+          data-menu-toggle
+        >
+          Menu
+        </button>
+        <nav class="nav-links" id="primary-nav" data-menu>
+          <a class="nav-link is-active" href="./index.html">Dashboard</a>
+          <a class="nav-link" href="./incident.html">Incident</a>
+          <a class="nav-link" href="#monitors">Monitors</a>
+        </nav>
+      </header>
+
+      <main class="page">
+        <section class="hero-card">
+          <div>
+            <p class="eyebrow">Shift Summary</p>
+            <h1>Core monitor health stays readable and actionable on mobile.</h1>
+            <p class="hero-copy">
+              This slice focuses on the dashboard and incident-triage surfaces at
+              375px and above, with responsive cards, compact controls, and
+              touch-sized actions.
+            </p>
+          </div>
+          <div class="hero-metrics">
+            <div class="hero-metric">
+              <span>Open incidents</span>
+              <strong>2</strong>
+            </div>
+            <div class="hero-metric">
+              <span>Monitors in scope</span>
+              <strong>12</strong>
+            </div>
+            <div class="hero-metric">
+              <span>Target viewport</span>
+              <strong>375px+</strong>
+            </div>
+          </div>
+        </section>
+
+        <section class="summary-grid" aria-label="Monitor summary">
+          <article class="summary-card healthy">
+            <p>Healthy</p>
+            <strong>42</strong>
+            <span>steady over last hour</span>
+          </article>
+          <article class="summary-card degraded">
+            <p>Degraded</p>
+            <strong>3</strong>
+            <span>latency spike in production</span>
+          </article>
+          <article class="summary-card incident">
+            <p>Open incidents</p>
+            <strong>2</strong>
+            <span>1 acknowledged, 1 paging</span>
+          </article>
+          <article class="summary-card paused">
+            <p>Paused</p>
+            <strong>5</strong>
+            <span>maintenance window until 02:00 UTC</span>
+          </article>
+        </section>
+
+        <section class="panel filters-panel">
+          <div class="panel-heading">
+            <div>
+              <p class="eyebrow">Monitor filters</p>
+              <h2>Keep triage compact on narrow screens.</h2>
+            </div>
+            <button
+              class="secondary-button filters-toggle"
+              type="button"
+              aria-expanded="false"
+              aria-controls="dashboard-filters"
+              data-filters-toggle
+            >
+              Filters
+            </button>
+          </div>
+
+          <form class="filters-grid" id="dashboard-filters" data-filters>
+            <label>
+              <span>Environment</span>
+              <select name="environment">
+                <option value="all">All</option>
+                <option value="production">Production</option>
+                <option value="staging">Staging</option>
+              </select>
+            </label>
+            <label>
+              <span>Status</span>
+              <select name="status">
+                <option value="all">All</option>
+                <option value="healthy">Healthy</option>
+                <option value="degraded">Degraded</option>
+                <option value="incident">Incident</option>
+                <option value="paused">Paused</option>
+              </select>
+            </label>
+            <label>
+              <span>Incident state</span>
+              <select name="incident">
+                <option value="all">All</option>
+                <option value="open">Open</option>
+                <option value="acknowledged">Acknowledged</option>
+                <option value="muted">Muted</option>
+                <option value="none">No incident</option>
+              </select>
+            </label>
+            <button class="secondary-button" type="reset">Reset</button>
+          </form>
+        </section>
+
+        <section class="dashboard-grid">
+          <article class="panel incident-queue">
+            <div class="panel-heading">
+              <div>
+                <p class="eyebrow">Open incidents</p>
+                <h2>Responders can jump straight into triage.</h2>
+              </div>
+              <a class="text-link" href="./incident.html">Open incident page</a>
+            </div>
+
+            <div class="incident-list">
+              <a class="incident-card" href="./incident.html">
+                <div>
+                  <span class="pill pill-incident">Paging</span>
+                  <h3>INC-204 checkout latency spike</h3>
+                  <p>checkout.example.com · Production · Open for 18m</p>
+                </div>
+                <span class="incident-link">Triage</span>
+              </a>
+
+              <a class="incident-card muted-card" href="./incident.html">
+                <div>
+                  <span class="pill pill-muted">Muted</span>
+                  <h3>INC-201 auth gateway retries</h3>
+                  <p>auth.example.com · Production · Waiting on vendor rollback</p>
+                </div>
+                <span class="incident-link">Review</span>
+              </a>
+            </div>
+          </article>
+
+          <article class="panel monitor-panel" id="monitors">
+            <div class="panel-heading">
+              <div>
+                <p class="eyebrow">Monitors</p>
+                <h2>Cards replace dense tables below tablet widths.</h2>
+              </div>
+              <p class="panel-note" data-results-count>Showing 4 monitors</p>
+            </div>
+
+            <div class="monitor-list" data-monitor-list>
+              <article
+                class="monitor-card"
+                data-environment="production"
+                data-status="incident"
+                data-incident="open"
+              >
+                <div class="monitor-topline">
+                  <div>
+                    <h3>checkout.example.com</h3>
+                    <p>Production · HTTP GET · Every 60s</p>
+                  </div>
+                  <span class="pill pill-incident">Incident</span>
+                </div>
+                <dl class="metric-pairs">
+                  <div>
+                    <dt>Last check</dt>
+                    <dd>502 in 7.3s</dd>
+                  </div>
+                  <div>
+                    <dt>Threshold</dt>
+                    <dd>3 failures</dd>
+                  </div>
+                  <div>
+                    <dt>Age</dt>
+                    <dd>18m</dd>
+                  </div>
+                  <div>
+                    <dt>Next run</dt>
+                    <dd>00:00:34</dd>
+                  </div>
+                </dl>
+                <div class="card-actions">
+                  <a class="primary-button" href="./incident.html">Open incident</a>
+                  <button class="secondary-button" type="button">Mute alerts</button>
+                </div>
+              </article>
+
+              <article
+                class="monitor-card"
+                data-environment="production"
+                data-status="degraded"
+                data-incident="acknowledged"
+              >
+                <div class="monitor-topline">
+                  <div>
+                    <h3>api.example.com</h3>
+                    <p>Production · HTTP GET · Every 30s</p>
+                  </div>
+                  <span class="pill pill-degraded">Degraded</span>
+                </div>
+                <dl class="metric-pairs">
+                  <div>
+                    <dt>Latency p95</dt>
+                    <dd>1.4s</dd>
+                  </div>
+                  <div>
+                    <dt>Status</dt>
+                    <dd>200-299</dd>
+                  </div>
+                  <div>
+                    <dt>Owner</dt>
+                    <dd>Platform</dd>
+                  </div>
+                  <div>
+                    <dt>Incident state</dt>
+                    <dd>Acknowledged</dd>
+                  </div>
+                </dl>
+                <div class="card-actions">
+                  <button class="primary-button" type="button">Acknowledge</button>
+                  <button class="secondary-button" type="button">Inspect checks</button>
+                </div>
+              </article>
+
+              <article
+                class="monitor-card"
+                data-environment="staging"
+                data-status="healthy"
+                data-incident="none"
+              >
+                <div class="monitor-topline">
+                  <div>
+                    <h3>status.staging.example.com</h3>
+                    <p>Staging · HTTP HEAD · Every 120s</p>
+                  </div>
+                  <span class="pill pill-healthy">Healthy</span>
+                </div>
+                <dl class="metric-pairs">
+                  <div>
+                    <dt>Last check</dt>
+                    <dd>204 in 241ms</dd>
+                  </div>
+                  <div>
+                    <dt>Response target</dt>
+                    <dd>&lt; 400ms</dd>
+                  </div>
+                  <div>
+                    <dt>Tags</dt>
+                    <dd>status-page</dd>
+                  </div>
+                  <div>
+                    <dt>Next run</dt>
+                    <dd>01:56</dd>
+                  </div>
+                </dl>
+                <div class="card-actions">
+                  <button class="secondary-button" type="button">View history</button>
+                </div>
+              </article>
+
+              <article
+                class="monitor-card"
+                data-environment="production"
+                data-status="paused"
+                data-incident="muted"
+              >
+                <div class="monitor-topline">
+                  <div>
+                    <h3>auth.example.com</h3>
+                    <p>Production · HTTP POST · Every 45s</p>
+                  </div>
+                  <span class="pill pill-paused">Paused</span>
+                </div>
+                <dl class="metric-pairs">
+                  <div>
+                    <dt>Window</dt>
+                    <dd>Database failover</dd>
+                  </div>
+                  <div>
+                    <dt>Resume</dt>
+                    <dd>02:00 UTC</dd>
+                  </div>
+                  <div>
+                    <dt>Pager</dt>
+                    <dd>Muted</dd>
+                  </div>
+                  <div>
+                    <dt>Updated by</dt>
+                    <dd>On-call</dd>
+                  </div>
+                </dl>
+                <div class="card-actions">
+                  <button class="secondary-button" type="button">Resume monitor</button>
+                </div>
+              </article>
+            </div>
+          </article>
+        </section>
+      </main>
+    </div>
+
+    <script src="./app.js"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,568 @@
+:root {
+  color-scheme: light;
+  --bg: #f4efe7;
+  --surface: rgba(255, 252, 247, 0.88);
+  --surface-strong: #fffdf8;
+  --ink: #16202a;
+  --muted: #5a6470;
+  --line: rgba(22, 32, 42, 0.12);
+  --brand: #123847;
+  --brand-soft: #d8e7eb;
+  --healthy: #d9f0df;
+  --healthy-ink: #1d6b3a;
+  --degraded: #f8e6b8;
+  --degraded-ink: #8a5d00;
+  --incident: #f6d1c8;
+  --incident-ink: #a93f22;
+  --paused: #dfe7f4;
+  --paused-ink: #36547d;
+  --muted-bg: #ece0f4;
+  --muted-ink: #6a4383;
+  --shadow: 0 22px 48px rgba(25, 33, 41, 0.08);
+  --radius-xl: 30px;
+  --radius-lg: 22px;
+  --radius-md: 16px;
+  --radius-sm: 12px;
+  --content-width: min(1180px, calc(100vw - 32px));
+  font-family: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Georgia, serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  min-width: 375px;
+}
+
+body {
+  margin: 0;
+  background:
+    radial-gradient(circle at top left, rgba(231, 198, 157, 0.48), transparent 28%),
+    radial-gradient(circle at right center, rgba(110, 157, 168, 0.16), transparent 26%),
+    linear-gradient(180deg, #f6f1ea 0%, #efe9de 100%);
+  color: var(--ink);
+  line-height: 1.5;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+button,
+select,
+textarea {
+  border: 0;
+}
+
+.app-shell {
+  width: var(--content-width);
+  margin: 0 auto;
+  padding: 24px 0 40px;
+}
+
+.topbar {
+  position: sticky;
+  top: 12px;
+  z-index: 5;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 16px;
+  align-items: center;
+  padding: 18px 22px;
+  border: 1px solid rgba(18, 56, 71, 0.18);
+  border-radius: var(--radius-xl);
+  background: rgba(18, 56, 71, 0.92);
+  color: #f9f7f2;
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(18px);
+}
+
+.brand {
+  display: inline-block;
+  font-size: clamp(1.6rem, 1.3rem + 0.8vw, 2.1rem);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.eyebrow {
+  margin: 0 0 6px;
+  font-size: 0.78rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: inherit;
+  opacity: 0.72;
+}
+
+.nav-links {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.nav-link,
+.menu-toggle,
+.secondary-button,
+.primary-button,
+.text-link {
+  min-height: 44px;
+}
+
+.nav-link,
+.menu-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 16px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  color: #f9f7f2;
+}
+
+.is-active {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.menu-toggle {
+  display: none;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+}
+
+.page {
+  display: grid;
+  gap: 20px;
+  margin-top: 20px;
+}
+
+.hero-card,
+.panel,
+.summary-card {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  background: var(--surface);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(16px);
+}
+
+.hero-card {
+  display: grid;
+  grid-template-columns: minmax(0, 2.1fr) minmax(260px, 1fr);
+  gap: 18px;
+  padding: 28px;
+}
+
+.hero-card h1,
+.panel h2 {
+  margin: 0;
+  line-height: 1.05;
+}
+
+.hero-card h1 {
+  font-size: clamp(2.1rem, 1.5rem + 2vw, 4.2rem);
+  max-width: 12ch;
+}
+
+.hero-copy,
+.panel-note,
+.incident-card p,
+.metric-pairs dd,
+.metric-pairs dt,
+.check-card p,
+.timeline-item p,
+.evidence-card p {
+  color: var(--muted);
+}
+
+.hero-copy {
+  max-width: 56ch;
+  font-size: 1.04rem;
+}
+
+.hero-metrics,
+.summary-grid,
+.filters-grid,
+.dashboard-grid,
+.monitor-list,
+.incident-layout,
+.action-grid,
+.evidence-list,
+.check-list {
+  display: grid;
+  gap: 16px;
+}
+
+.hero-metrics {
+  align-content: start;
+}
+
+.hero-metric {
+  padding: 18px;
+  border-radius: var(--radius-md);
+  background: var(--surface-strong);
+  border: 1px solid rgba(18, 56, 71, 0.1);
+}
+
+.hero-metric span,
+.summary-card p,
+.pill,
+.timeline-time {
+  font-size: 0.83rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.hero-metric strong {
+  display: block;
+  margin-top: 6px;
+  font-size: 1.25rem;
+}
+
+.summary-grid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.summary-card {
+  padding: 18px;
+}
+
+.summary-card strong {
+  display: block;
+  margin: 8px 0;
+  font-size: 2rem;
+}
+
+.summary-card span {
+  color: var(--muted);
+  font-size: 0.96rem;
+}
+
+.healthy {
+  background: linear-gradient(180deg, var(--healthy), rgba(255, 255, 255, 0.92));
+}
+
+.degraded {
+  background: linear-gradient(180deg, var(--degraded), rgba(255, 255, 255, 0.92));
+}
+
+.incident {
+  background: linear-gradient(180deg, var(--incident), rgba(255, 255, 255, 0.92));
+}
+
+.paused {
+  background: linear-gradient(180deg, var(--paused), rgba(255, 255, 255, 0.92));
+}
+
+.panel {
+  padding: 22px;
+}
+
+.panel-heading {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 18px;
+}
+
+.panel-heading h2 {
+  font-size: clamp(1.35rem, 1.15rem + 0.4vw, 1.8rem);
+}
+
+.filters-grid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  align-items: end;
+}
+
+.filters-grid label,
+.note-field {
+  display: grid;
+  gap: 8px;
+}
+
+.filters-grid span,
+.note-field span {
+  font-size: 0.88rem;
+  color: var(--muted);
+}
+
+select,
+textarea {
+  width: 100%;
+  padding: 14px 16px;
+  border: 1px solid rgba(22, 32, 42, 0.12);
+  border-radius: var(--radius-sm);
+  background: var(--surface-strong);
+  color: var(--ink);
+}
+
+.dashboard-grid,
+.incident-layout {
+  grid-template-columns: minmax(0, 1.25fr) minmax(320px, 0.9fr);
+}
+
+.monitor-panel {
+  min-width: 0;
+}
+
+.incident-list,
+.metric-pairs,
+.card-actions,
+.incident-title-row,
+.monitor-topline {
+  display: flex;
+  gap: 12px;
+}
+
+.incident-list {
+  flex-direction: column;
+}
+
+.incident-card,
+.monitor-card,
+.evidence-card,
+.check-card {
+  display: grid;
+  gap: 14px;
+  padding: 18px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--surface-strong);
+}
+
+.incident-card {
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+}
+
+.muted-card {
+  background: linear-gradient(180deg, rgba(236, 224, 244, 0.72), rgba(255, 255, 255, 0.96));
+}
+
+.incident-link,
+.text-link {
+  color: var(--brand);
+  font-weight: 700;
+}
+
+.monitor-list,
+.incident-layout,
+.evidence-list,
+.check-list {
+  grid-template-columns: 1fr;
+}
+
+.monitor-topline,
+.card-actions,
+.action-grid {
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.metric-pairs {
+  flex-wrap: wrap;
+  padding: 0;
+  margin: 0;
+}
+
+.metric-pairs div {
+  min-width: 130px;
+  flex: 1 1 140px;
+}
+
+.metric-pairs dt {
+  margin-bottom: 4px;
+}
+
+.metric-pairs dd {
+  margin: 0;
+  font-size: 1.04rem;
+  color: var(--ink);
+}
+
+.primary-button,
+.secondary-button,
+.text-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px 16px;
+  border-radius: 999px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.primary-button {
+  background: var(--brand);
+  color: #f9f7f2;
+}
+
+.secondary-button {
+  background: rgba(18, 56, 71, 0.08);
+  color: var(--brand);
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 7px 10px;
+  border-radius: 999px;
+  font-weight: 700;
+}
+
+.pill-healthy {
+  background: var(--healthy);
+  color: var(--healthy-ink);
+}
+
+.pill-degraded {
+  background: var(--degraded);
+  color: var(--degraded-ink);
+}
+
+.pill-incident {
+  background: var(--incident);
+  color: var(--incident-ink);
+}
+
+.pill-paused {
+  background: var(--paused);
+  color: var(--paused-ink);
+}
+
+.pill-muted {
+  background: var(--muted-bg);
+  color: var(--muted-ink);
+}
+
+.incident-page .sticky-actions {
+  position: sticky;
+  top: 104px;
+  z-index: 4;
+}
+
+.action-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.timeline {
+  display: grid;
+  gap: 16px;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.timeline-item {
+  display: grid;
+  grid-template-columns: 88px minmax(0, 1fr);
+  gap: 14px;
+  padding: 18px;
+  border-radius: var(--radius-md);
+  background: var(--surface-strong);
+  border: 1px solid var(--line);
+}
+
+.timeline-time {
+  color: var(--brand);
+}
+
+.check-card,
+.evidence-card {
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+}
+
+.is-hidden {
+  display: none !important;
+}
+
+@media (max-width: 960px) {
+  .hero-card,
+  .dashboard-grid,
+  .incident-layout,
+  .summary-grid,
+  .filters-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .incident-page .sticky-actions {
+    top: 92px;
+  }
+}
+
+@media (max-width: 720px) {
+  .app-shell {
+    padding-top: 16px;
+  }
+
+  .topbar {
+    grid-template-columns: 1fr auto;
+    padding: 16px;
+  }
+
+  .menu-toggle {
+    display: inline-flex;
+  }
+
+  .nav-links {
+    display: none;
+    grid-column: 1 / -1;
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .nav-links.is-open {
+    display: flex;
+  }
+
+  .hero-card,
+  .panel,
+  .summary-card {
+    border-radius: 18px;
+  }
+
+  .hero-card,
+  .panel {
+    padding: 18px;
+  }
+
+  .filters-panel .filters-grid {
+    display: none;
+  }
+
+  .filters-panel .filters-grid.is-open {
+    display: grid;
+  }
+
+  .incident-card,
+  .timeline-item,
+  .check-card,
+  .evidence-card {
+    grid-template-columns: 1fr;
+  }
+
+  .incident-link,
+  .pill {
+    justify-self: start;
+  }
+
+  .action-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .card-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}


### PR DESCRIPTION
## Summary
- advance #12 with a focused responsive frontend slice for the dashboard and incident triage flows
- add a mobile-first static dashboard and incident page sized for 375px+ viewports with stacked cards, compact filters, and touch-sized controls
- add lightweight client-side interactions for mobile menu, filter drawer, dashboard filtering, and incident action timeline updates
- add a QA checklist for viewport-focused manual verification

## Reviewer Verify
- open `index.html` at 375px width and confirm there is no horizontal scrolling through summary, filters, incidents, or monitor cards
- open `incident.html` at 375px width and confirm the action controls, evidence cards, timeline, and recent checks remain readable and tappable
- exercise the menu toggle, filter drawer, and incident action buttons and confirm the layout stays intact

## Tests
- `node --check app.js`
- `python3 -c "from html.parser import HTMLParser; from pathlib import Path; parser = HTMLParser(); [parser.feed(Path(p).read_text()) for p in ('index.html','incident.html')]; print('html-parse-ok')"`
- `curl -I http://127.0.0.1:8000/index.html`
- `curl -I http://127.0.0.1:8000/incident.html`

## Scope Notes
- this PR intentionally stays on the frontend/mobile-support slice only and does not add backend data wiring or issue-closing automation