### PR TITLE
[REQ-001] Add monitor create and edit pages

### DIFF
--- a/docs/qa/traceability-matrix.md
+++ b/docs/qa/traceability-matrix.md
@@ -1,13 +1,13 @@
 # Traceability Matrix -- site-monitor
 
 > **Last updated:** 2026-04-06
-> **Updated by:** superiority-core
+> **Updated by:** superiority-developer
 
 ## Requirements Traceability
 
 | ID | Requirement | Issue | PR | Test File:Line | Staging Evidence | Status |
 |----|-------------|-------|----|----------------|------------------|--------|
-| REQ-001 | As a reliability engineer, I want to create and manage monitors so that important sites and endpoints are checked automatically. | [#1](https://github.com/IDNTEQ/site-monitor/issues/1) |  | `` |  | Pending |
+| REQ-001 | As a reliability engineer, I want to create and manage monitors so that important sites and endpoints are checked automatically. | [#1](https://github.com/IDNTEQ/site-monitor/issues/1) |  | `test/api.test.js:22`, `test/api.test.js:80`, `test/monitor-service.test.js:95`, `test/monitor-service.test.js:130`, `test/monitor-service.test.js:176`, `test/page-routes.test.js:90`, `test/page-routes.test.js:119`, `test/page-routes.test.js:147`, `test/page-routes.test.js:228` |  | Needs Review |
 | REQ-002 | As a reliability engineer, I want to configure alert policies and maintenance windows so that responders are notified only when failures are actionable. | [#2](https://github.com/IDNTEQ/site-monitor/issues/2) |  | `` |  | Pending |
 | REQ-003 | As an on-call responder, I want a dashboard of current monitor status and open incidents so that I can see what needs attention immediately. | [#3](https://github.com/IDNTEQ/site-monitor/issues/3) |  | `` |  | Pending |
 | REQ-004 | As an on-call responder, I want an incident timeline with failure evidence so that I can triage without searching raw logs elsewhere. | [#4](https://github.com/IDNTEQ/site-monitor/issues/4) |  | `` |  | Pending |

--- a/src/http/app.js
+++ b/src/http/app.js
@@ -68,6 +68,41 @@ function htmlResult(statusCode, body, headers) {
   };
 }
 
+function parseIntegerField(value) {
+  if (value === undefined || value === null || value === "") {
+    return undefined;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  return Number.isNaN(parsed) ? Number.NaN : parsed;
+}
+
+function parseTagField(value) {
+  if (typeof value !== "string") {
+    return [];
+  }
+
+  return value
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function buildMonitorInputFromPageBody(body = {}) {
+  return {
+    name: body.name ?? "",
+    environment: body.environment ?? "",
+    url: body.url ?? "",
+    method: body.method ?? "",
+    intervalSeconds: parseIntegerField(body.intervalSeconds),
+    timeoutMs: parseIntegerField(body.timeoutMs),
+    expectedStatusMin: parseIntegerField(body.expectedStatusMin),
+    expectedStatusMax: parseIntegerField(body.expectedStatusMax),
+    keyword: body.keyword ?? "",
+    tags: parseTagField(body.tags),
+  };
+}
+
 export async function handleApiRequest({
   service,
   method,
@@ -184,20 +219,81 @@ export async function handlePageRequest({
     return htmlResult(200, renderDashboardPage(dashboard, filters));
   }
 
+  if (method === "POST" && pathname === "/monitors") {
+    try {
+      const monitor = await service.createMonitor(buildMonitorInputFromPageBody(body));
+      return htmlResult(303, "", {
+        location: `/monitors/${monitor.id}`,
+      });
+    } catch (error) {
+      if (!(error instanceof MonitorValidationError)) {
+        throw error;
+      }
+
+      const dashboard = await service.getDashboard();
+      return htmlResult(
+        422,
+        renderDashboardPage(dashboard, {}, {
+          values: body ?? {},
+          errors: error.fieldErrors,
+        }),
+      );
+    }
+  }
+
   const monitorRouteMatch = pathname.match(/^\/monitors\/([^/]+)$/);
   if (method === "GET" && monitorRouteMatch) {
     const detail = await service.getMonitorDetail(monitorRouteMatch[1]);
     return htmlResult(200, renderMonitorDetailPage(detail));
   }
 
+  if (method === "POST" && monitorRouteMatch) {
+    try {
+      await service.updateMonitor(
+        monitorRouteMatch[1],
+        buildMonitorInputFromPageBody(body),
+      );
+      return htmlResult(303, "", {
+        location: `/monitors/${monitorRouteMatch[1]}`,
+      });
+    } catch (error) {
+      if (!(error instanceof MonitorValidationError)) {
+        throw error;
+      }
+
+      const detail = await service.getMonitorDetail(monitorRouteMatch[1]);
+      return htmlResult(
+        422,
+        renderMonitorDetailPage(detail, {
+          values: body ?? {},
+          errors: error.fieldErrors,
+        }),
+      );
+    }
+  }
+
   const monitorActionRouteMatch = pathname.match(/^\/monitors\/([^/]+)\/actions$/);
   if (method === "POST" && monitorActionRouteMatch) {
-    await service.updateMonitor(monitorActionRouteMatch[1], {
-      action: body?.action,
-    });
-    return htmlResult(303, "", {
-      location: `/monitors/${monitorActionRouteMatch[1]}`,
-    });
+    try {
+      await service.updateMonitor(monitorActionRouteMatch[1], {
+        action: body?.action,
+      });
+      return htmlResult(303, "", {
+        location: `/monitors/${monitorActionRouteMatch[1]}`,
+      });
+    } catch (error) {
+      if (!(error instanceof MonitorValidationError)) {
+        throw error;
+      }
+
+      const detail = await service.getMonitorDetail(monitorActionRouteMatch[1]);
+      return htmlResult(
+        422,
+        renderMonitorDetailPage(detail, {
+          errors: error.fieldErrors,
+        }),
+      );
+    }
   }
 
   const incidentRouteMatch = pathname.match(/^\/incidents\/([^/]+)$/);

--- a/src/http/pages.js
+++ b/src/http/pages.js
@@ -224,7 +224,94 @@ function renderActionButtons(buttons) {
     .join("")}</div>`;
 }
 
-export function renderDashboardPage(dashboard, filters = {}) {
+function renderFieldError(errors, fieldName, idPrefix) {
+  if (!errors?.[fieldName]) {
+    return "";
+  }
+
+  return `<p class="field-error" id="${escapeHtml(idPrefix)}-${escapeHtml(fieldName)}-error">${escapeHtml(errors[fieldName])}</p>`;
+}
+
+function resolveFieldValue(values, fieldName, fallback = "") {
+  const value = values?.[fieldName];
+
+  if (Array.isArray(value)) {
+    return value.join(", ");
+  }
+
+  if (value === undefined || value === null) {
+    return fallback;
+  }
+
+  return value;
+}
+
+function renderMonitorFormFields(values = {}, errors = {}, idPrefix = "monitor-form") {
+  const method = String(resolveFieldValue(values, "method", "GET")).toUpperCase();
+  const methodOptions = ["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]
+    .map(
+      (option) =>
+        `<option value="${option}"${method === option ? " selected" : ""}>${option}</option>`,
+    )
+    .join("");
+
+  return `<div class="grid cols-2">
+      <div>
+        <label for="${escapeHtml(idPrefix)}-name">Name</label>
+        <input id="${escapeHtml(idPrefix)}-name" name="name" value="${escapeHtml(resolveFieldValue(values, "name"))}" aria-describedby="${errors.name ? `${idPrefix}-name-error` : ""}" />
+        ${renderFieldError(errors, "name", idPrefix)}
+      </div>
+      <div>
+        <label for="${escapeHtml(idPrefix)}-environment">Environment</label>
+        <input id="${escapeHtml(idPrefix)}-environment" name="environment" value="${escapeHtml(resolveFieldValue(values, "environment"))}" aria-describedby="${errors.environment ? `${idPrefix}-environment-error` : ""}" />
+        ${renderFieldError(errors, "environment", idPrefix)}
+      </div>
+      <div>
+        <label for="${escapeHtml(idPrefix)}-url">URL</label>
+        <input id="${escapeHtml(idPrefix)}-url" name="url" value="${escapeHtml(resolveFieldValue(values, "url"))}" aria-describedby="${errors.url ? `${idPrefix}-url-error` : ""}" />
+        ${renderFieldError(errors, "url", idPrefix)}
+      </div>
+      <div>
+        <label for="${escapeHtml(idPrefix)}-method">Method</label>
+        <select id="${escapeHtml(idPrefix)}-method" name="method" aria-describedby="${errors.method ? `${idPrefix}-method-error` : ""}">
+          ${methodOptions}
+        </select>
+        ${renderFieldError(errors, "method", idPrefix)}
+      </div>
+      <div>
+        <label for="${escapeHtml(idPrefix)}-intervalSeconds">Interval seconds</label>
+        <input id="${escapeHtml(idPrefix)}-intervalSeconds" name="intervalSeconds" type="number" min="10" value="${escapeHtml(resolveFieldValue(values, "intervalSeconds", 60))}" aria-describedby="${errors.intervalSeconds ? `${idPrefix}-intervalSeconds-error` : ""}" />
+        ${renderFieldError(errors, "intervalSeconds", idPrefix)}
+      </div>
+      <div>
+        <label for="${escapeHtml(idPrefix)}-timeoutMs">Timeout milliseconds</label>
+        <input id="${escapeHtml(idPrefix)}-timeoutMs" name="timeoutMs" type="number" min="100" max="30000" value="${escapeHtml(resolveFieldValue(values, "timeoutMs", 1000))}" aria-describedby="${errors.timeoutMs ? `${idPrefix}-timeoutMs-error` : ""}" />
+        ${renderFieldError(errors, "timeoutMs", idPrefix)}
+      </div>
+      <div>
+        <label for="${escapeHtml(idPrefix)}-expectedStatusMin">Expected status min</label>
+        <input id="${escapeHtml(idPrefix)}-expectedStatusMin" name="expectedStatusMin" type="number" min="100" max="599" value="${escapeHtml(resolveFieldValue(values, "expectedStatusMin", 200))}" aria-describedby="${errors.expectedStatusMin ? `${idPrefix}-expectedStatusMin-error` : ""}" />
+        ${renderFieldError(errors, "expectedStatusMin", idPrefix)}
+      </div>
+      <div>
+        <label for="${escapeHtml(idPrefix)}-expectedStatusMax">Expected status max</label>
+        <input id="${escapeHtml(idPrefix)}-expectedStatusMax" name="expectedStatusMax" type="number" min="100" max="599" value="${escapeHtml(resolveFieldValue(values, "expectedStatusMax", 299))}" aria-describedby="${errors.expectedStatusMax ? `${idPrefix}-expectedStatusMax-error` : ""}" />
+        ${renderFieldError(errors, "expectedStatusMax", idPrefix)}
+      </div>
+      <div>
+        <label for="${escapeHtml(idPrefix)}-keyword">Keyword match</label>
+        <input id="${escapeHtml(idPrefix)}-keyword" name="keyword" value="${escapeHtml(resolveFieldValue(values, "keyword"))}" aria-describedby="${errors.keyword ? `${idPrefix}-keyword-error` : ""}" />
+        ${renderFieldError(errors, "keyword", idPrefix)}
+      </div>
+      <div>
+        <label for="${escapeHtml(idPrefix)}-tags">Tags</label>
+        <input id="${escapeHtml(idPrefix)}-tags" name="tags" value="${escapeHtml(resolveFieldValue(values, "tags"))}" aria-describedby="${errors.tags ? `${idPrefix}-tags-error` : ""}" />
+        ${renderFieldError(errors, "tags", idPrefix)}
+      </div>
+    </div>`;
+}
+
+export function renderDashboardPage(dashboard, filters = {}, createFormState = {}) {
   const summaryCards = [
     ["Healthy", dashboard.summary.healthy, "o"],
     ["Degraded", dashboard.summary.degraded, "~"],
@@ -239,6 +326,14 @@ export function renderDashboardPage(dashboard, filters = {}) {
     <p class="muted">Showing the last ${escapeHtml(dashboard.dataset.days)} days from ${escapeHtml(
       dashboard.dataset.startedAt,
     )} to ${escapeHtml(dashboard.dataset.asOf)}.</p>
+    <section aria-labelledby="create-monitor-title">
+      <h2 id="create-monitor-title">Create monitor</h2>
+      ${renderErrorSummary(createFormState.errors)}
+      <form action="/monitors" method="post">
+        ${renderMonitorFormFields(createFormState.values, createFormState.errors, "create-monitor")}
+        <button type="submit">Create monitor</button>
+      </form>
+    </section>
     <section aria-labelledby="summary-title">
       <h2 id="summary-title">Current health summary</h2>
       <div class="grid cols-4">
@@ -329,7 +424,7 @@ export function renderDashboardPage(dashboard, filters = {}) {
   );
 }
 
-export function renderMonitorDetailPage(detail) {
+export function renderMonitorDetailPage(detail, formState = {}) {
   const buttons =
     detail.monitor.status === "active"
       ? [
@@ -348,6 +443,7 @@ export function renderMonitorDetailPage(detail) {
     "",
     `<p><a href="/dashboard">Back to dashboard</a></p>
     <h1>Monitor Detail</h1>
+    ${renderErrorSummary(formState.errors)}
     <section aria-labelledby="monitor-summary-title">
       <h2 id="monitor-summary-title">${escapeHtml(detail.monitor.name)}</h2>
       ${renderKeyValueRows([
@@ -363,6 +459,11 @@ export function renderMonitorDetailPage(detail) {
         ["Last check", detail.monitor.lastCheckAt ?? "No checks yet"],
       ])}
     </section>
+    <form action="/monitors/${escapeHtml(detail.monitor.id)}" method="post" aria-labelledby="monitor-edit-title">
+      <h2 id="monitor-edit-title">Edit monitor</h2>
+      ${renderMonitorFormFields(formState.values ?? detail.monitor, formState.errors, "edit-monitor")}
+      <button type="submit">Save monitor changes</button>
+    </form>
     <form action="/monitors/${escapeHtml(detail.monitor.id)}/actions" method="post" aria-labelledby="monitor-actions-title">
       <h2 id="monitor-actions-title">Monitor actions</h2>
       ${

--- a/test/page-routes.test.js
+++ b/test/page-routes.test.js
@@ -16,7 +16,7 @@ function createServiceBundle() {
   };
 }
 
-test("GET /dashboard renders accessible filters, summary labels, and detail links", async () => {
+test("GET /dashboard renders accessible filters, create form, summary labels, and detail links", async () => {
   const { service, repository } = createServiceBundle();
 
   const healthy = await service.createMonitor({
@@ -75,6 +75,9 @@ test("GET /dashboard renders accessible filters, summary labels, and detail link
   assert.equal(result.statusCode, 200);
   assert.equal(result.contentType, "text/html; charset=utf-8");
   assert.match(result.body, /<main id="main-content">/);
+  assert.match(result.body, /<h2 id="create-monitor-title">Create monitor<\/h2>/);
+  assert.match(result.body, /<form action="\/monitors" method="post">/);
+  assert.match(result.body, /<label for="create-monitor-name">Name<\/label>/);
   assert.match(result.body, /<label for="environment-filter">Environment<\/label>/);
   assert.match(result.body, /aria-live="polite"/);
   assert.match(result.body, /Open incidents/);
@@ -84,7 +87,64 @@ test("GET /dashboard renders accessible filters, summary labels, and detail link
   assert.match(result.body, /\/incidents\/INC-204/);
 });
 
-test("GET /monitors/:monitorId renders monitor detail with descriptive action labels and tabular history", async () => {
+test("POST /monitors creates a monitor from the dashboard form and redirects to detail", async () => {
+  const { service, repository } = createServiceBundle();
+
+  const result = await handlePageRequest({
+    service,
+    method: "POST",
+    pathname: "/monitors",
+    body: {
+      name: "Checkout",
+      environment: "production",
+      url: "https://example.com/checkout",
+      method: "GET",
+      intervalSeconds: "60",
+      timeoutMs: "1000",
+      expectedStatusMin: "200",
+      expectedStatusMax: "299",
+      keyword: "healthy",
+      tags: "checkout, prod",
+    },
+  });
+
+  const created = (await repository.list())[0];
+
+  assert.equal(result.statusCode, 303);
+  assert.equal(result.headers.location, `/monitors/${created.id}`);
+  assert.equal(created.name, "Checkout");
+  assert.deepEqual(created.tags, ["checkout", "prod"]);
+});
+
+test("POST /monitors returns field-level validation errors in HTML", async () => {
+  const { service } = createServiceBundle();
+
+  const result = await handlePageRequest({
+    service,
+    method: "POST",
+    pathname: "/monitors",
+    body: {
+      name: "",
+      environment: "",
+      url: "bad-url",
+      method: "TRACE",
+      intervalSeconds: "5",
+      timeoutMs: "10",
+      expectedStatusMin: "700",
+      expectedStatusMax: "200",
+      keyword: "ok",
+      tags: "",
+    },
+  });
+
+  assert.equal(result.statusCode, 422);
+  assert.match(result.body, /Please fix the following/);
+  assert.match(result.body, /Name is required\./);
+  assert.match(result.body, /Environment is required\./);
+  assert.match(result.body, /URL must be an absolute HTTP or HTTPS URL\./);
+});
+
+test("GET /monitors/:monitorId renders monitor detail with edit form, descriptive action labels, and tabular history", async () => {
   const { service, repository } = createServiceBundle();
 
   const monitor = await service.createMonitor({
@@ -147,6 +207,10 @@ test("GET /monitors/:monitorId renders monitor detail with descriptive action la
   assert.equal(result.statusCode, 200);
   assert.match(result.body, /<h1>Monitor Detail<\/h1>/);
   assert.match(result.body, /Checkout/);
+  assert.match(result.body, /<h2 id="monitor-edit-title">Edit monitor<\/h2>/);
+  assert.match(result.body, /<form action="\/monitors\/.*" method="post" aria-labelledby="monitor-edit-title">/);
+  assert.match(result.body, /<label for="edit-monitor-name">Name<\/label>/);
+  assert.match(result.body, /Save monitor changes/);
   assert.match(
     result.body,
     /<button type="submit" name="action" value="pause">Pause monitor<\/button>/,
@@ -159,6 +223,48 @@ test("GET /monitors/:monitorId renders monitor detail with descriptive action la
   assert.match(result.body, /<table>/);
   assert.match(result.body, /Latest incident/);
   assert.match(result.body, /\/incidents\/INC-301/);
+});
+
+test("POST /monitors/:monitorId updates monitor configuration and redirects", async () => {
+  const { service, repository } = createServiceBundle();
+
+  const monitor = await service.createMonitor({
+    name: "Checkout",
+    environment: "production",
+    url: "https://example.com/checkout",
+    method: "GET",
+    intervalSeconds: 60,
+    timeoutMs: 1000,
+    expectedStatusMin: 200,
+    expectedStatusMax: 299,
+  });
+
+  const result = await handlePageRequest({
+    service,
+    method: "POST",
+    pathname: `/monitors/${monitor.id}`,
+    body: {
+      name: "Checkout API",
+      environment: "staging",
+      url: "https://staging.example.com/checkout",
+      method: "HEAD",
+      intervalSeconds: "120",
+      timeoutMs: "1500",
+      expectedStatusMin: "200",
+      expectedStatusMax: "399",
+      keyword: "ok",
+      tags: "checkout, staging",
+    },
+  });
+
+  const updated = await repository.getById(monitor.id);
+
+  assert.equal(result.statusCode, 303);
+  assert.equal(result.headers.location, `/monitors/${monitor.id}`);
+  assert.equal(updated.name, "Checkout API");
+  assert.equal(updated.environment, "staging");
+  assert.equal(updated.method, "HEAD");
+  assert.deepEqual(updated.tags, ["checkout", "staging"]);
 });
 
 test("GET /incidents/:incidentId renders explicit action labels and source-order timeline", async () => {


### PR DESCRIPTION
Closes #1

## What changed
- add dashboard create-monitor form that posts directly into the existing monitor service
- add monitor detail edit form plus field-level HTML validation rendering for create and update failures
- keep pause, resume, and archive actions on the detail page and document REQ-001 traceability coverage

## How to verify
- run: npm test
- create a monitor from /dashboard and confirm it redirects to /monitors/:id
- edit a monitor from /monitors/:id and confirm changes persist while pause, resume, and archive still work

## Risks
- forms currently cover the REQ-001 monitor fields only; alert policy and maintenance window editing remain in later issue slices